### PR TITLE
chore: adiciona template de pull request

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,39 @@
+<!--
+Tira os comentários (essas linhas com <!-- -->) antes de criar o PR.
+Preenche cada seção, mesmo que seja com uma frase só. PR sem descrição
+é difícil de revisar.
+-->
+
+## 📝 Resumo
+
+<!-- O que esse PR faz, em 1 ou 2 frases. Ex: "Adiciona a aba de Turmas no dashboard do coordenador". -->
+
+## 💡 Por que
+
+<!-- Qual era o problema ou a user story que motivou a mudança.
+     Pode citar o número da issue/US, ex: "Resolve a US05 T01". -->
+
+## 🛠️ O que mudou
+
+<!-- Lista do que foi mexido. Pode ser bullet curto. Ex:
+- Cria src/services/turmas.js com formulário e modal
+- Adiciona a aba "Turmas" no dashboardcoord
+- Popula uma turma de exemplo em popularLocalStorage
+-->
+
+## 🧪 Como testar
+
+<!-- Passo a passo pra quem for revisar. Ex:
+1. npm run dev
+2. Logar como coordenador (matrícula 001 / senha 123456)
+3. Clicar na aba "Turmas"
+4. Conferir se o modal abre e a turma aparece no card
+-->
+
+## ✅ Checklist
+
+- [ ] Rodei `npm run dev` e testei no navegador
+- [ ] Rodei `npm run build` e não deu erro
+- [ ] Não tem `console.log` ou comentário `[OBS:]` esquecido
+- [ ] Os imports que não estão sendo usados foram removidos
+- [ ] Se mexi em algo do design system (style.css, tailwind.config.js), conferi se outras telas continuam funcionando


### PR DESCRIPTION
## Resumo

Adiciona um template padrão pra PRs em `.github/pull_request_template.md`.

## Por que

Vários PRs estão sendo abertos com descrição vazia ou só com uma frase, o que dificulta o review (a gente não sabe o que era pra arrumar, qual era o bug, o que esperar). Um template simples ajuda a galera a lembrar de preencher resumo, motivação, o que mudou, como testar e checklist básico.

## O que mudou

- Cria `.github/pull_request_template.md` na raiz do repositório (fora da pasta `Clarify/`, igual o `LICENSE` e o `README.md`)

## Como testar

1. Abrir um PR novo qualquer
2. Conferir se o GitHub preenche automaticamente o corpo com o template
3. Verificar se os comentários HTML (`<!-- ... -->`) aparecem como guia mas somem no preview

## Observações

O template é só um guia. Quem abrir PR pode tirar/adicionar seções se fizer sentido.