### PR TITLE
feat(auth): adiciona toggle de exibicao de senha no login e registro

### DIFF
--- a/clarify-next/src/app/login/page.tsx
+++ b/clarify-next/src/app/login/page.tsx
@@ -2,6 +2,7 @@
 
 import Image from 'next/image'
 import Link from 'next/link'
+import { Eye, EyeOff } from 'lucide-react'
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { useForm } from 'react-hook-form'
@@ -10,6 +11,7 @@ import { useAuth } from '@/context/AuthContext'
 import { loginSchema, type LoginFormData } from '@/schemas/auth'
 
 export default function LoginPage() {
+  const [mostrarSenha, setMostrarSenha] = useState(false)
   const [error, setError] = useState('')
   const [isLoading, setIsLoading] = useState(false)
   const router = useRouter()
@@ -46,6 +48,15 @@ export default function LoginPage() {
   }
 
   return (
+    <>
+      <style>{`
+        input[type="password"]::-ms-reveal,
+        input[type="password"]::-ms-clear,
+        input[type="password"]::-webkit-credentials-auto-fill-button,
+        input[type="password"]::-webkit-textfield-decoration-container {
+          display: none !important;
+        }
+      `}</style>
     <div className="min-h-screen w-full flex items-center justify-center p-4 relative overflow-hidden bg-brand-surface">
       {/* Fundo Geométrico com Losangos */}
       <div
@@ -108,24 +119,22 @@ export default function LoginPage() {
               Chave de Segurança
             </label>
             <div className="relative">
-              <span className="absolute inset-y-0 left-0 pl-3 flex items-center text-gray-400">
-                <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"
-                  />
-                </svg>
-              </span>
               <input
                 id="login-senha"
-                type="password"
+                type={mostrarSenha ? 'text' : 'password'}
                 {...register('senha')}
                 placeholder="••••••••"
-                className="block w-full pl-10 pr-3 py-3 border border-gray-200 rounded-lg bg-gray-50 text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-brand-primary focus:border-transparent transition-all"
+                className="block w-full pl-3 pr-10 py-3 border border-gray-200 rounded-lg bg-gray-50 text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-brand-primary focus:border-transparent transition-all"
                 disabled={isLoading}
               />
+              <button
+                type="button"
+                onClick={() => setMostrarSenha(!mostrarSenha)}
+                tabIndex={-1}
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 transition-colors"
+              >
+                {mostrarSenha ? <EyeOff size={20} /> : <Eye size={20} />}
+              </button>
             </div>
             {errors.senha && (
               <p className="text-xs text-red-600 mt-1 ml-1">{errors.senha.message}</p>
@@ -162,5 +171,6 @@ export default function LoginPage() {
         </div>
       </div>
     </div>
+    </>
   )
 }

--- a/clarify-next/src/app/registro/page.tsx
+++ b/clarify-next/src/app/registro/page.tsx
@@ -2,6 +2,7 @@
 
 import Image from 'next/image'
 import Link from 'next/link'
+import { Eye, EyeOff } from 'lucide-react'
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { useForm } from 'react-hook-form'
@@ -10,6 +11,7 @@ import { useAuth } from '@/context/AuthContext'
 import { registroSchema, type RegistroFormData } from '@/schemas/auth'
 
 export default function RegistroPage() {
+  const [mostrarSenha, setMostrarSenha] = useState(false)
   const [error, setError] = useState('')
   const [isLoading, setIsLoading] = useState(false)
   const router = useRouter()
@@ -52,6 +54,15 @@ export default function RegistroPage() {
   }
 
   return (
+    <>
+      <style>{`
+        input[type="password"]::-ms-reveal,
+        input[type="password"]::-ms-clear,
+        input[type="password"]::-webkit-credentials-auto-fill-button,
+        input[type="password"]::-webkit-textfield-decoration-container {
+          display: none !important;
+        }
+      `}</style>
     <div className="min-h-screen w-full flex items-center justify-center p-4 relative overflow-hidden bg-brand-surface">
       {/* Fundo Geométrico com Losangos */}
       <div
@@ -172,24 +183,22 @@ export default function RegistroPage() {
               Chave de Segurança
             </label>
             <div className="relative">
-              <span className="absolute inset-y-0 left-0 pl-3 flex items-center text-gray-400">
-                <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"
-                  />
-                </svg>
-              </span>
               <input
                 id="registro-securityKey"
-                type="password"
+                type={mostrarSenha ? 'text' : 'password'}
                 {...register('senha')}
                 placeholder="••••••••"
-                className="block w-full pl-10 pr-3 py-3 border border-gray-200 rounded-lg bg-gray-50 text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-brand-primary focus:border-transparent transition-all"
+                className="block w-full pl-3 pr-10 py-3 border border-gray-200 rounded-lg bg-gray-50 text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-brand-primary focus:border-transparent transition-all"
                 disabled={isLoading}
               />
+              <button
+                type="button"
+                onClick={() => setMostrarSenha(!mostrarSenha)}
+                tabIndex={-1}
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 transition-colors"
+              >
+                {mostrarSenha ? <EyeOff size={20} /> : <Eye size={20} />}
+              </button>
             </div>
             {errors.senha && (
               <p className="text-xs text-red-600 mt-1 ml-1">{errors.senha.message}</p>
@@ -252,5 +261,6 @@ export default function RegistroPage() {
         </div>
       </div>
     </div>
+    </>
   )
 }


### PR DESCRIPTION
📝 Resumo
Adiciona botão de toggle (ícone de olho) nos campos de senha do login e registro para exibir/esconder caracteres.

💡 Por que
CA06 da feature ENZ-58 (Autenticação unificada). Remove também o olho nativo do navegador que ficava duplicado com o novo toggle.

🛠️ O que mudou
- src/app/login/page.tsx — adiciona estado mostrarSenha, toggle Eye/EyeOff, remove ícone de cadeado antigo, esconde olho nativo do navegador via CSS
- src/app/registro/page.tsx — mesmas alterações do login

🧪 Como testar
1. npm run dev
2. Acessar /login e digitar no campo de senha
3. Clicar no ícone de olho à direita — senha deve alternar entre mascarada e visível
4. Repetir o teste em /registro
5. Verificar que o olho nativo do Chrome/Edge não aparece mais

✅ Checklist
- Rodei npm run dev e testei no navegador
- Rodei npm run build e não deu erro
- Não tem console.log ou comentário esquecido
- Os imports que não estão sendo usados foram removidos
- Se mexi em algo do design system (style.css, tailwind.config.js), conferi se outras telas continuam funcionando