### PR TITLE
feat: migração fetch inline para hooks tanstack

### DIFF
--- a/clarify-next/src/app/(dashboard)/dashboardcoord/page.tsx
+++ b/clarify-next/src/app/(dashboard)/dashboardcoord/page.tsx
@@ -2,15 +2,14 @@
 
 import { useReducer, useMemo, useCallback } from 'react';
 import { useSearchParams } from 'next/navigation';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQueryClient } from '@tanstack/react-query';
 import { ModalCriarTurma } from '@/components/coordenador/ModalCriarTurma';
 import { ModalFeedback } from '@/components/coordenador/ModalFeedback';
 import { ModalDetalhesDemanda } from '@/components/demandas/ModalDetalhesDemanda';
 import { FormAdicionarAluno } from '@/components/coordenador/FormAdicionarAluno';
 import { useAuth } from '@/context/AuthContext';
 import { useDemandas } from '@/hooks/useDemandas';
-import { useUsuarios } from '@/hooks/useUsuarios';
-import type { Cargo, UsuarioLogado } from '@/types';
+import { useUsuarios, useAlunosDoCoordenador } from '@/hooks/useUsuarios';
 import { useTurmas } from '@/hooks/useTurmas';
 import { atualizarStatusDemanda } from '@/lib/demandas';
 import { VisaoGeral } from './_components/VisaoGeral';
@@ -18,17 +17,6 @@ import { ListaAlunos } from './_components/ListaAlunos';
 import { ListaDemandas } from './_components/ListaDemandas';
 import { ListaTurmas } from './_components/ListaTurmas';
 import { dashboardUiReducer, initialDashboardUiState } from './_components/dashboardState';
-
-function mapProfileToUser(row: Record<string, unknown>): UsuarioLogado {
-  return {
-    id: row.id as string,
-    nome: row.nome as string,
-    matricula: row.matricula as string,
-    email: row.email as string,
-    cargo: row.cargo as Cargo,
-    coordenador_id: (row.coordenador_id as string) ?? undefined,
-  };
-}
 
 type DashView = 'nome' | 'alunos' | 'demandas' | 'turmas' | 'adicionar';
 
@@ -47,15 +35,7 @@ export default function DashboardCoordPage() {
 
   const [ui, dispatch] = useReducer(dashboardUiReducer, initialDashboardUiState);
 
-  const { data: alunosDoCoord = [] } = useQuery({
-    queryKey: ['alunos', usuario?.id],
-    queryFn: async () => {
-      const res = await fetch(`/api/perfis?coordenadorId=${encodeURIComponent(usuario!.id)}&cargo=aluno`)
-      const data = await res.json()
-      return (data ?? []).map(mapProfileToUser) as UsuarioLogado[]
-    },
-    enabled: !!usuario?.id,
-  });
+  const { data: alunosDoCoord = [] } = useAlunosDoCoordenador(usuario?.id);
 
   const alunoIds = useMemo(() => new Set(alunosDoCoord.map((a) => a.id)), [alunosDoCoord]);
 
@@ -116,7 +96,7 @@ export default function DashboardCoordPage() {
     const aluno = alunosDoCoord.find((a) => a.matricula === matricula);
     if (aluno) {
       await usuariosHook.deletar(aluno.id);
-      queryClient.invalidateQueries({ queryKey: ['alunos', usuario?.id] });
+      queryClient.invalidateQueries({ queryKey: ['students', usuario?.id] });
     }
   }, [alunosDoCoord, usuariosHook, queryClient, usuario?.id]);
 

--- a/clarify-next/src/hooks/useUsuarios.ts
+++ b/clarify-next/src/hooks/useUsuarios.ts
@@ -34,6 +34,19 @@ async function existe(matricula: string, email: string): Promise<boolean> {
   return (data ?? []).length > 0
 }
 
+export function useAlunosDoCoordenador(coordenadorId: string | null | undefined) {
+  return useQuery({
+    queryKey: ['students', coordenadorId],
+    queryFn: async () => {
+      if (!coordenadorId) return []
+      const res = await fetch(`/api/perfis?coordenadorId=${encodeURIComponent(coordenadorId)}&cargo=aluno`)
+      const data = await res.json()
+      return (data ?? []).map(mapProfileToUser) as UsuarioLogado[]
+    },
+    enabled: !!coordenadorId,
+  })
+}
+
 export function useUsuarios() {
   const queryClient = useQueryClient()
 


### PR DESCRIPTION
This pull request refactors how the list of students associated with a coordinator is fetched and managed in the dashboard. The main change is the extraction of the logic for fetching students into a reusable custom hook, improving code clarity and reusability. Additionally, related query keys are updated for consistency.

**Refactoring and code reuse:**

* Introduced a new custom hook `useAlunosDoCoordenador` in `useUsuarios.ts` to encapsulate the logic for fetching students by coordinator, replacing the in-component query logic.
* Updated `dashboardcoord/page.tsx` to use the new `useAlunosDoCoordenador` hook instead of defining the query inline.

**Query key and import improvements:**

* Changed the query key from `['alunos', usuario?.id]` to `['students', usuario?.id]` for consistency in both fetching and invalidating queries. [[1]](diffhunk://#diff-58ff474fd56a763bacfc350f736fc619de89a3b0383b6edabcc6f49902f0f279L119-R99) [[2]](diffhunk://#diff-821e290e754826a26d96416cc81829719032d34af05593413875afa4c6370088R37-R49)
* Cleaned up imports in `dashboardcoord/page.tsx` to remove unused items and include the new hook.

**Code cleanup:**

* Removed the now-unnecessary `mapProfileToUser` function from `dashboardcoord/page.tsx`, as it is now handled within the custom hook.