### PR TITLE
feat: interface administrativa para gerar chaves de ativação (ENZ-62)

### DIFF
--- a/clarify-next/scripts/seed-supabase.ts
+++ b/clarify-next/scripts/seed-supabase.ts
@@ -4,23 +4,6 @@
 // Uso: npx tsx scripts/seed-supabase.ts
 // ═════════════════════════════════════════════════════════════════
 
-import { createClient } from '@supabase/supabase-js'
-
-/**
- * Cliente Supabase com service role — usado para criar usuários
- * via Admin API e popular tabelas.
- */
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!,
-  {
-    auth: {
-      autoRefreshToken: false,
-      persistSession: false,
-    },
-  }
-)
-
 // ─── Main ──────────────────────────────────────────────────────
 
 async function main() {

--- a/clarify-next/src/app/(dashboard)/dashboardcoord/_components/ListaChaves.tsx
+++ b/clarify-next/src/app/(dashboard)/dashboardcoord/_components/ListaChaves.tsx
@@ -1,0 +1,145 @@
+'use client'
+
+import { useState } from 'react'
+import { Copy, Check, KeyRound } from 'lucide-react'
+import { Badge } from '@/components/ui/Badge'
+
+interface Chave {
+  id: string
+  code: string
+  used: boolean
+  created_at: string
+}
+
+interface ListaChavesProps {
+  chaves: Chave[]
+  loading: boolean
+  gerando: boolean
+  onGerar: () => void
+  ultimaGerada: Chave | null
+}
+
+export function ListaChaves({
+  chaves,
+  loading,
+  gerando,
+  onGerar,
+  ultimaGerada,
+}: ListaChavesProps) {
+  const [copiedId, setCopiedId] = useState<string | null>(null)
+
+  const copiarChave = async (code: string, id: string) => {
+    await navigator.clipboard.writeText(code)
+    setCopiedId(id)
+    setTimeout(() => setCopiedId(null), 2000)
+  }
+
+  const formatarData = (data: string) => {
+    return new Date(data).toLocaleDateString('pt-BR', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+  }
+
+  return (
+    <section>
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-xl font-bold text-gray-900">Chaves de Ativação</h2>
+        <button
+          type="button"
+          onClick={onGerar}
+          disabled={gerando}
+          className="flex items-center gap-2 px-4 py-2 bg-brand-primary text-white rounded-lg font-semibold text-sm hover:bg-orange-700 transition-colors cursor-pointer border-none disabled:opacity-50"
+        >
+          {gerando ? (
+            <span className="inline-block w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+          ) : (
+            <span>+</span>
+          )}
+          Gerar nova chave
+        </button>
+      </div>
+
+      {ultimaGerada && (
+        <div className="mb-4 p-4 bg-green-50 border border-green-200 rounded-xl flex items-center gap-3">
+          <span className="text-green-700 text-sm font-medium">
+            Chave gerada:{' '}
+            <strong className="font-mono text-base">{ultimaGerada.code}</strong>
+          </span>
+          <button
+            type="button"
+            onClick={() => copiarChave(ultimaGerada.code, ultimaGerada.id)}
+            className="ml-auto text-green-600 hover:text-green-800 transition-colors"
+          >
+            {copiedId === ultimaGerada.id ? (
+              <Check className="w-4 h-4" />
+            ) : (
+              <Copy className="w-4 h-4" />
+            )}
+          </button>
+        </div>
+      )}
+
+      {loading ? (
+        <div className="flex justify-center py-16">
+          <span className="inline-block w-8 h-8 border-2 border-orange-600/30 border-t-orange-600 rounded-full animate-spin" />
+        </div>
+      ) : chaves.length === 0 ? (
+        <div className="flex flex-col items-center justify-center py-16 text-gray-500 gap-3">
+          <KeyRound className="w-12 h-12 text-gray-300" />
+          <p className="text-lg font-medium">Nenhuma chave cadastrada</p>
+          <p className="text-sm">Gere a primeira chave de ativação para começar.</p>
+        </div>
+      ) : (
+        <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-gray-100 bg-gray-50">
+                  <th className="text-left px-5 py-3 font-semibold text-gray-600">Chave</th>
+                  <th className="text-left px-5 py-3 font-semibold text-gray-600">Status</th>
+                  <th className="text-left px-5 py-3 font-semibold text-gray-600 hidden sm:table-cell">
+                    Criada em
+                  </th>
+                  <th className="text-left px-5 py-3 font-semibold text-gray-600 w-20">Ações</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-50">
+                {chaves.map((chave) => (
+                  <tr key={chave.id} className="hover:bg-orange-50/30 transition-colors">
+                    <td className="px-5 py-3 font-mono text-gray-700">{chave.code}</td>
+                    <td className="px-5 py-3">
+                      <Badge variant={chave.used ? 'default' : 'concluido'}>
+                        {chave.used ? 'Usada' : 'Disponível'}
+                      </Badge>
+                    </td>
+                    <td className="px-5 py-3 text-gray-500 hidden sm:table-cell">
+                      {formatarData(chave.created_at)}
+                    </td>
+                    <td className="px-5 py-3">
+                      <button
+                        type="button"
+                        onClick={() => copiarChave(chave.code, chave.id)}
+                        className="p-2 rounded-lg hover:bg-gray-100 transition-colors text-gray-500 hover:text-orange-600"
+                        title="Copiar chave"
+                      >
+                        {copiedId === chave.id ? (
+                          <Check className="w-4 h-4 text-green-600" />
+                        ) : (
+                          <Copy className="w-4 h-4" />
+                        )}
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/clarify-next/src/app/(dashboard)/dashboardcoord/page.tsx
+++ b/clarify-next/src/app/(dashboard)/dashboardcoord/page.tsx
@@ -11,16 +11,18 @@ import { useAuth } from '@/context/AuthContext';
 import { useDemandas } from '@/hooks/useDemandas';
 import { useUsuarios, useAlunosDoCoordenador } from '@/hooks/useUsuarios';
 import { useTurmas } from '@/hooks/useTurmas';
+import { useChaves } from '@/hooks/useChaves';
 import { atualizarStatusDemanda } from '@/lib/demandas';
 import { useUIStore } from '@/store/uiStore';
 import { VisaoGeral } from './_components/VisaoGeral';
 import { ListaAlunos } from './_components/ListaAlunos';
 import { ListaDemandas } from './_components/ListaDemandas';
 import { ListaTurmas } from './_components/ListaTurmas';
+import { ListaChaves } from './_components/ListaChaves';
 
-type DashView = 'nome' | 'alunos' | 'demandas' | 'turmas' | 'adicionar';
+type DashView = 'nome' | 'alunos' | 'demandas' | 'turmas' | 'adicionar' | 'chaves';
 
-const VIEWS: DashView[] = ['nome', 'alunos', 'demandas', 'turmas', 'adicionar'];
+const VIEWS: DashView[] = ['nome', 'alunos', 'demandas', 'turmas', 'adicionar', 'chaves'];
 
 export default function DashboardCoordPage() {
   const queryClient = useQueryClient();
@@ -28,6 +30,7 @@ export default function DashboardCoordPage() {
   const { demandas, recarregar: recarregarDemandas } = useDemandas();
   const usuariosHook = useUsuarios();
   const turmasHook = useTurmas();
+  const { chaves, loading: chavesLoading, gerar: gerarChave, gerando: gerandoChave, ultimaGerada } = useChaves();
   const searchParams = useSearchParams();
 
   const rawView = searchParams.get('view') as DashView | null;
@@ -161,6 +164,16 @@ export default function DashboardCoordPage() {
         <ListaTurmas
           turmas={turmasDoCoord}
           onCriarTurma={() => setModalTurmaAberta(true)}
+        />
+      )}
+
+      {view === 'chaves' && (
+        <ListaChaves
+          chaves={chaves}
+          loading={chavesLoading}
+          gerando={gerandoChave}
+          onGerar={() => gerarChave()}
+          ultimaGerada={ultimaGerada}
         />
       )}
 

--- a/clarify-next/src/app/api/chaves/route.ts
+++ b/clarify-next/src/app/api/chaves/route.ts
@@ -1,0 +1,50 @@
+import { createClient } from '@/lib/supabase/server'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { NextResponse } from 'next/server'
+
+function gerarChave(tamanho = 8): string {
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
+  let chave = ''
+  for (let i = 0; i < tamanho; i++) {
+    chave += chars.charAt(Math.floor(Math.random() * chars.length))
+  }
+  return chave
+}
+
+export async function GET() {
+  const supabase = await createClient()
+
+  const { data, error } = await supabase
+    .from('chaves_ativacao')
+    .select('*')
+    .order('created_at', { ascending: false })
+
+  if (error) {
+    return NextResponse.json(
+      { ok: false, mensagem: error.message },
+      { status: 500 }
+    )
+  }
+
+  return NextResponse.json(data)
+}
+
+export async function POST() {
+  const supabaseAdmin = createAdminClient()
+  const chave = gerarChave(8)
+
+  const { data, error } = await supabaseAdmin
+    .from('chaves_ativacao')
+    .insert({ code: chave, used: false })
+    .select()
+    .single()
+
+  if (error) {
+    return NextResponse.json(
+      { ok: false, mensagem: error.message },
+      { status: 500 }
+    )
+  }
+
+  return NextResponse.json(data)
+}

--- a/clarify-next/src/components/layout/Sidebar.tsx
+++ b/clarify-next/src/components/layout/Sidebar.tsx
@@ -7,6 +7,7 @@ import {
   Plus,
   FileText,
   Shield,
+  KeyRound,
   LogOut,
 } from 'lucide-react';
 import type { Cargo } from '@/types';
@@ -20,7 +21,7 @@ interface SidebarProps {
 
 /**
  * Sidebar desktop com navegação por cargo
- * - Coordenador: Início, Alunos, Adicionar, Demandas, Turmas
+ * - Coordenador: Início, Alunos, Adicionar, Demandas, Turmas, Chaves
  * - Aluno: Central de Demandas, Documentos
  */
 export function Sidebar({
@@ -37,6 +38,7 @@ export function Sidebar({
           { id: 'adicionar', label: 'Adicionar aluno', icon: Plus },
           { id: 'demandas', label: 'Demandas', icon: FileText },
           { id: 'turmas', label: 'Turmas', icon: Shield },
+          { id: 'chaves', label: 'Chaves', icon: KeyRound },
         ]
       : [
           { id: 'nome', label: 'Início', icon: User },

--- a/clarify-next/src/components/ui/Dialog.tsx
+++ b/clarify-next/src/components/ui/Dialog.tsx
@@ -2,7 +2,6 @@
 
 import * as React from "react"
 import * as DialogPrimitive from "@radix-ui/react-dialog"
-import { X } from "lucide-react"
 import { cn } from "@/lib/utils"
 
 const Dialog = DialogPrimitive.Root

--- a/clarify-next/src/hooks/useChaves.ts
+++ b/clarify-next/src/hooks/useChaves.ts
@@ -1,0 +1,42 @@
+'use client'
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+
+interface Chave {
+  id: string
+  code: string
+  used: boolean
+  created_at: string
+}
+
+export function useChaves() {
+  const queryClient = useQueryClient()
+
+  const { data: chaves = [], isLoading: loading } = useQuery<Chave[]>({
+    queryKey: ['chaves'],
+    queryFn: async () => {
+      const res = await fetch('/api/chaves')
+      const data = await res.json()
+      return Array.isArray(data) ? data : []
+    },
+  })
+
+  const gerarMutation = useMutation({
+    mutationFn: async () => {
+      const res = await fetch('/api/chaves', { method: 'POST' })
+      if (!res.ok) throw new Error('Erro ao gerar chave')
+      return res.json() as Promise<Chave>
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['chaves'] })
+    },
+  })
+
+  return {
+    chaves,
+    loading,
+    gerar: gerarMutation.mutate,
+    gerando: gerarMutation.isPending,
+    ultimaGerada: gerarMutation.data ?? null,
+  }
+}


### PR DESCRIPTION
## 📝 Resumo

Adiciona a view de Gerenciamento de Chaves de Ativação no dashboard do coordenador, permitindo gerar novas chaves e visualizar as existentes com status.

## 💡 Por que

Coordenadores precisam gerar e distribuir chaves de ativação para que novos coordenadores possam se cadastrar no sistema. Antes não havia interface para isso — as chaves só existiam no banco via seed.

## 🛠️ O que mudou

- `src/hooks/useChaves.ts` — hook com TanStack Query para listar e gerar chaves
- `src/app/(dashboard)/dashboardcoord/_components/ListaChaves.tsx` — componente com tabela de chaves, badge de status, botão copiar e banner de confirmação
- `src/app/api/chaves/route.ts` — GET (RLS para coordenador) e POST (admin client para burlar RLS no insert)
- `src/app/(dashboard)/dashboardcoord/page.tsx` — adicionada view `chaves` ao DashView, acessível via `/dashboardcoord?view=chaves`
- `src/components/layout/Sidebar.tsx` — item "Chaves" com ícone KeyRound na navegação do coordenador

## 🧪 Como testar

1. `npm run dev`
2. Logar como coordenador (matrícula `123` / senha `123456`)
3. Clicar em "Chaves" na sidebar
4. Conferir se as 3 chaves seed aparecem na tabela (123, 456, 789) com badge "Disponível"
5. Clicar em "Gerar nova chave" — uma nova chave de 8 caracteres deve aparecer no banner verde e na tabela
6. Clicar no ícone de cópia em qualquer chave — deve copiar para a área de transferência
7. Confirmar que aluno não vê o item "Chaves" na sidebar

## ✅ Checklist

- [x] Rodei `npm run dev` e testei no navegador
- [x] Rodei `npm run build` e não deu erro
- [x] Não tem `console.log` ou comentário `[OBS:]` esquecido
- [x] Os imports que não estão sendo usados foram removidos
- [x] Se mexi em algo do design system, conferi se outras telas continuam funcionando
Link: https://github.com/Lucas-Vinicius-dev/Clarify/pull/new/feat/enz-62-gerenciar-chaves-ativacao