### PR TITLE
Refactor demand notifications and restrict creation for students

### DIFF
--- a/clarify-next/src/app/(dashboard)/centraldemandas/page.tsx
+++ b/clarify-next/src/app/(dashboard)/centraldemandas/page.tsx
@@ -71,7 +71,6 @@ export default function CentralDemandasPage() {
   const handleCriarDemanda = useCallback((dados: { tipo: TipoDemanda; descricao: string }) => {
     if (!usuario?.id) return;
     criar({
-      alunoId: usuario.id,
       tipo: dados.tipo,
       descricao: dados.descricao,
     });

--- a/clarify-next/src/app/(dashboard)/centraldemandas/page.tsx
+++ b/clarify-next/src/app/(dashboard)/centraldemandas/page.tsx
@@ -145,7 +145,9 @@ export default function CentralDemandasPage() {
                     onVerDetalhes={handleVerDetalhes}
                   />
                 ))}
-                <CardNovaDemanda onClick={() => setModalNovaAberta(true)} />
+                {usuario?.cargo === 'aluno' && (
+                  <CardNovaDemanda onClick={() => setModalNovaAberta(true)} />
+                )}
               </div>
             </section>
           )}
@@ -155,7 +157,9 @@ export default function CentralDemandasPage() {
               <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
                 <EstadoVazio />
                 <div className="sm:col-span-2 lg:col-span-3">
-                  <CardNovaDemanda onClick={() => setModalNovaAberta(true)} />
+                  {usuario?.cargo === 'aluno' && (
+                    <CardNovaDemanda onClick={() => setModalNovaAberta(true)} />
+                  )}
                 </div>
               </div>
             </section>
@@ -197,13 +201,17 @@ export default function CentralDemandasPage() {
                       onVerDetalhes={handleVerDetalhes}
                     />
                   ))}
-                  <CardNovaDemanda onClick={() => setModalNovaAberta(true)} />
+                  {usuario?.cargo === 'aluno' && (
+                    <CardNovaDemanda onClick={() => setModalNovaAberta(true)} />
+                  )}
                 </>
               ) : (
                 <>
                   <EstadoVazio />
                   <div className="sm:col-span-2 lg:col-span-3">
-                    <CardNovaDemanda onClick={() => setModalNovaAberta(true)} />
+                    {usuario?.cargo === 'aluno' && (
+                      <CardNovaDemanda onClick={() => setModalNovaAberta(true)} />
+                    )}
                   </div>
                 </>
               )}
@@ -240,7 +248,9 @@ export default function CentralDemandasPage() {
             </section>
           )}
 
-          <FabMobile onClick={() => setModalNovaAberta(true)} />
+          {usuario?.cargo === 'aluno' && (
+            <FabMobile onClick={() => setModalNovaAberta(true)} />
+          )}
         </>
       )}
 

--- a/clarify-next/src/app/api/demandas/route.ts
+++ b/clarify-next/src/app/api/demandas/route.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@/lib/supabase/server'
+import { novaDemandaSchema } from '@/schemas/demandas'
 import { NextResponse } from 'next/server'
 
 export async function GET(request: Request) {
@@ -23,11 +24,23 @@ export async function POST(request: Request) {
     createClient(),
   ])
 
+  const validacao = novaDemandaSchema.safeParse(dados)
+  if (!validacao.success) {
+    return NextResponse.json(
+      {
+        ok: false,
+        mensagem: 'Dados inválidos.',
+        erros: validacao.error.flatten().fieldErrors,
+      },
+      { status: 400 },
+    )
+  }
+
   const { data: protocolo } = await supabase.rpc('gerar_proximo_protocolo')
   if (!protocolo) {
     return NextResponse.json(
       { ok: false, mensagem: 'Erro ao gerar protocolo.' },
-      { status: 500 }
+      { status: 500 },
     )
   }
 
@@ -36,8 +49,8 @@ export async function POST(request: Request) {
     .insert({
       protocolo,
       aluno_id: dados.alunoId,
-      tipo: dados.tipo,
-      descricao: dados.descricao,
+      tipo: validacao.data.tipo,
+      descricao: validacao.data.descricao,
     })
     .select()
     .single()
@@ -45,7 +58,7 @@ export async function POST(request: Request) {
   if (!data) {
     return NextResponse.json(
       { ok: false, mensagem: 'Erro ao criar demanda.' },
-      { status: 500 }
+      { status: 500 },
     )
   }
 

--- a/clarify-next/src/app/api/demandas/route.ts
+++ b/clarify-next/src/app/api/demandas/route.ts
@@ -71,7 +71,7 @@ export async function POST(request: Request) {
     .from('demandas')
     .insert({
       protocolo,
-      aluno_id: dados.alunoId,
+      aluno_id: user.id,
       tipo: validacao.data.tipo,
       descricao: validacao.data.descricao,
     })

--- a/clarify-next/src/app/api/demandas/route.ts
+++ b/clarify-next/src/app/api/demandas/route.ts
@@ -1,3 +1,4 @@
+import { createAdminClient } from '@/lib/supabase/admin'
 import { createClient } from '@/lib/supabase/server'
 import { novaDemandaSchema } from '@/schemas/demandas'
 import { NextResponse } from 'next/server'
@@ -33,6 +34,28 @@ export async function POST(request: Request) {
         erros: validacao.error.flatten().fieldErrors,
       },
       { status: 400 },
+    )
+  }
+
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) {
+    return NextResponse.json(
+      { ok: false, mensagem: 'Não autorizado.' },
+      { status: 401 },
+    )
+  }
+
+  const supabaseAdmin = createAdminClient()
+  const { data: profile } = await supabaseAdmin
+    .from('profiles')
+    .select('cargo')
+    .eq('id', user.id)
+    .single()
+
+  if (profile?.cargo !== 'aluno') {
+    return NextResponse.json(
+      { ok: false, mensagem: 'Apenas alunos podem criar demandas.' },
+      { status: 403 },
     )
   }
 

--- a/clarify-next/src/components/demandas/ModalNovaDemanda.tsx
+++ b/clarify-next/src/components/demandas/ModalNovaDemanda.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback } from 'react';
-import { ArrowRight, AlertCircle, X } from 'lucide-react';
+import { ArrowRight, X } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Dialog, DialogContent, DialogHeader, DialogFooter } from '@/components/ui/Dialog';

--- a/clarify-next/src/components/demandas/ModalNovaDemanda.tsx
+++ b/clarify-next/src/components/demandas/ModalNovaDemanda.tsx
@@ -134,12 +134,6 @@ export function ModalNovaDemanda({ open, onClose, usuario, onSubmit }: ModalNova
               </div>
             </section>
 
-            {errors.tipo && (
-              <div className="mt-4 inline-flex items-start gap-2 text-xs font-semibold text-rose-700 bg-rose-50 border border-rose-200 rounded-lg px-3 py-2">
-                <AlertCircle className="w-4 h-4 mt-px shrink-0" />
-                <span>{errors.tipo.message}</span>
-              </div>
-            )}
           </div>
 
           <DialogFooter>

--- a/clarify-next/src/hooks/useDemandas.ts
+++ b/clarify-next/src/hooks/useDemandas.ts
@@ -40,7 +40,7 @@ export function useDemandas(opcoes?: UseDemandasOptions) {
   })
 
   const criarMutation = useMutation({
-    mutationFn: async (dados: { alunoId: string; tipo: TipoDemanda; descricao: string }) => {
+    mutationFn: async (dados: { tipo: TipoDemanda; descricao: string }) => {
       const res = await fetch('/api/demandas', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/clarify-next/src/schemas/demandas.ts
+++ b/clarify-next/src/schemas/demandas.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 import { TIPOS_DEMANDA } from '@/types'
 
-export const tipoDemandaSchema = z.enum(TIPOS_DEMANDA)
+export const tipoDemandaSchema = z.enum(TIPOS_DEMANDA, 'Selecione o tipo de solicitação.')
 
 export const novaDemandaSchema = z.object({
   tipo: tipoDemandaSchema,

--- a/clarify-next/src/types/index.ts
+++ b/clarify-next/src/types/index.ts
@@ -23,6 +23,8 @@ export const TIPOS_DEMANDA = [
   'Troca de Turma',
   'Solicitação de Histórico',
   'Justificativa de Falta',
+  'Transferência',
+  'Segunda Chamada',
 ] as const;
 
 export type TipoDemanda = typeof TIPOS_DEMANDA[number];


### PR DESCRIPTION
This pull request introduces several improvements to the demand creation flow, focusing on access control, validation, and user interface adjustments. The main goal is to ensure that only users with the role of "aluno" (student) can create new demands, and to provide better validation and error handling throughout the process.

**Access control and validation improvements:**

* The API endpoint in `route.ts` now validates input data using `novaDemandaSchema` and restricts demand creation to users with the "aluno" role. If the user is not a student or the data is invalid, appropriate error responses are returned. [[1]](diffhunk://#diff-2d33503bc21fe3ec3d6f92816065d311a7b870e5d940bdec30e8b09a7aa71290R1-R3) [[2]](diffhunk://#diff-2d33503bc21fe3ec3d6f92816065d311a7b870e5d940bdec30e8b09a7aa71290R28-R66) [[3]](diffhunk://#diff-2d33503bc21fe3ec3d6f92816065d311a7b870e5d940bdec30e8b09a7aa71290L39-R84)
* The demand type schema (`tipoDemandaSchema`) now includes a custom error message, and two new demand types ("Transferência" and "Segunda Chamada") have been added. [[1]](diffhunk://#diff-09b860b010d48793a87878fae693b7c9b1bc7535083fdb2b354314eb00e4613cL4-R4) [[2]](diffhunk://#diff-5dd1381ebe4c75dcec6d3cf428b64de28bf97019d8d4d7fa030903506998710cR26-R27)

**User interface adjustments:**

* The "Nova Demanda" (New Demand) card and floating action button (`CardNovaDemanda`, `FabMobile`) are now only visible to users with the "aluno" role in `CentralDemandasPage`. [[1]](diffhunk://#diff-4f0f57fd8ceb8792dc7ca0a3e464b5f071b5da395147b154db3636dcea47565aR148-R150) [[2]](diffhunk://#diff-4f0f57fd8ceb8792dc7ca0a3e464b5f071b5da395147b154db3636dcea47565aR160-R162) [[3]](diffhunk://#diff-4f0f57fd8ceb8792dc7ca0a3e464b5f071b5da395147b154db3636dcea47565aR204-R214) [[4]](diffhunk://#diff-4f0f57fd8ceb8792dc7ca0a3e464b5f071b5da395147b154db3636dcea47565aR251-R253)
* Removed redundant error display for the "tipo" field in the new demand modal, likely because validation is now handled elsewhere.