### PR TITLE
feat: view Minhas turmas no dashboard do aluno

### DIFF
--- a/clarify-next/src/app/(dashboard)/centraldemandas/_components/ListaMinhasTurmas.tsx
+++ b/clarify-next/src/app/(dashboard)/centraldemandas/_components/ListaMinhasTurmas.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { useMemo } from 'react';
+import { Users, Shield } from 'lucide-react';
+import type { Turma } from '@/types';
+import { Card } from '@/components/ui/Card';
+import { Badge } from '@/components/ui/Badge';
+import { useUsuarios } from '@/hooks/useUsuarios';
+
+interface ListaMinhasTurmasProps {
+  turmas: Turma[];
+}
+
+export function ListaMinhasTurmas({ turmas }: ListaMinhasTurmasProps) {
+  const { usuarios } = useUsuarios();
+
+  const nomesPorId = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const u of usuarios) map.set(u.id, u.nome);
+    return map;
+  }, [usuarios]);
+
+  if (turmas.length === 0) {
+    return (
+      <section className="space-y-4">
+        <h2 className="text-xl font-bold text-gray-900">Minhas turmas</h2>
+        <Card className="p-8 text-center">
+          <Users className="w-8 h-8 text-gray-300 mx-auto mb-3" />
+          <p className="text-sm text-gray-500">
+            Você ainda não está vinculado a nenhuma turma.
+          </p>
+        </Card>
+      </section>
+    );
+  }
+
+  return (
+    <section className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-xl font-bold text-gray-900">Minhas turmas</h2>
+        <Badge>{turmas.length} turma{turmas.length !== 1 ? 's' : ''}</Badge>
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {turmas.map((turma) => {
+          const coordenador = nomesPorId.get(turma.coordenador_id);
+          return (
+            <Card
+              key={turma.id}
+              className="p-5 hover:-translate-y-1 transition-transform duration-200 ease-out"
+            >
+              <div className="flex items-start gap-3 mb-3">
+                <div className="w-10 h-10 rounded-xl bg-brand-primary/10 flex items-center justify-center shrink-0">
+                  <Shield className="w-5 h-5 text-brand-primary" />
+                </div>
+                <div className="space-y-1 min-w-0">
+                  <h3 className="text-lg font-semibold text-gray-900 truncate">
+                    {turma.nome}
+                  </h3>
+                  <p className="text-sm text-gray-500 truncate">{turma.disciplina}</p>
+                </div>
+              </div>
+              <div className="flex items-center gap-2 text-sm text-gray-600">
+                <Users className="w-4 h-4 text-gray-400 shrink-0" />
+                <span className="truncate">
+                  {coordenador ?? 'Coordenador'}
+                </span>
+              </div>
+            </Card>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/clarify-next/src/app/(dashboard)/centraldemandas/page.tsx
+++ b/clarify-next/src/app/(dashboard)/centraldemandas/page.tsx
@@ -15,19 +15,22 @@ import { ModalNovaDemanda } from '@/components/demandas/ModalNovaDemanda';
 import { ModalDetalhesDemanda } from '@/components/demandas/ModalDetalhesDemanda';
 import { useDemandas } from '@/hooks/useDemandas';
 import { usePerfil } from '@/hooks/usePerfil';
+import { useTurmas } from '@/hooks/useTurmas';
 import { useAuth } from '@/context/AuthContext';
 import { useFiltrosStore } from '@/store/filtrosStore';
 import { useUIStore } from '@/store/uiStore';
 import type { TipoDemanda } from '@/types';
+import { ListaMinhasTurmas } from './_components/ListaMinhasTurmas';
 
-type StudentView = 'nome' | 'demandas';
-const VIEWS: StudentView[] = ['nome', 'demandas'];
+type StudentView = 'nome' | 'demandas' | 'turmas';
+const VIEWS: StudentView[] = ['nome', 'demandas', 'turmas'];
 
 export default function CentralDemandasPage() {
   const { usuario } = useAuth();
   const { demandas, criar } = useDemandas(
     usuario ? { alunoId: usuario.id } : undefined
   );
+  const { turmas } = useTurmas();
   const searchParams = useSearchParams();
   const router = useRouter();
 
@@ -86,6 +89,11 @@ export default function CentralDemandasPage() {
       (a, b) => new Date(b.dataAtualizacao).getTime() - new Date(a.dataAtualizacao).getTime()
     ).slice(0, 6),
     [demandas]
+  );
+
+  const minhasTurmas = useMemo(
+    () => usuario ? turmas.filter((t) => t.alunos.includes(usuario.id)) : [],
+    [turmas, usuario]
   );
 
   return (
@@ -251,6 +259,10 @@ export default function CentralDemandasPage() {
             <FabMobile onClick={() => setModalNovaAberta(true)} />
           )}
         </>
+      )}
+
+      {view === 'turmas' && (
+        <ListaMinhasTurmas turmas={minhasTurmas} />
       )}
 
       <ModalNovaDemanda

--- a/clarify-next/src/components/layout/Sidebar.tsx
+++ b/clarify-next/src/components/layout/Sidebar.tsx
@@ -22,7 +22,7 @@ interface SidebarProps {
 /**
  * Sidebar desktop com navegação por cargo
  * - Coordenador: Início, Alunos, Adicionar, Demandas, Turmas, Chaves
- * - Aluno: Central de Demandas, Documentos
+ * - Aluno: Central de Demandas, Minhas turmas
  */
 export function Sidebar({
   cargo,
@@ -43,6 +43,7 @@ export function Sidebar({
       : [
           { id: 'nome', label: 'Início', icon: User },
           { id: 'demandas', label: 'Minhas demandas', icon: FileText },
+          { id: 'turmas', label: 'Minhas turmas', icon: Shield },
         ];
 
   return (


### PR DESCRIPTION
Closes #126

## Contexto
O aluno não conseguia ver em quais turmas estava matriculado. O backend já permitia (RLS `turmas_select_own_or_matriculado` via `is_aluno_in_turma`), mas faltava a UI.

## O que foi feito
- Item **Minhas turmas** na sidebar do aluno (`Sidebar.tsx`)
- Nova view `turmas` em `/centraldemandas` com a seção `ListaMinhasTurmas`
- Cards com nome, disciplina e coordenador responsável (nome resolvido de `profiles`)
- Estado vazio quando o aluno não está em nenhuma turma

## Como testar
1. Logar como aluno matriculado em ao menos uma turma
2. Acessar **Minhas turmas** na sidebar
3. Validar listagem correta e estado vazio para aluno sem turma