### PR TITLE
feat(ca05): exibe nome do aluno no card de demanda do coordenador

### DIFF
--- a/clarify-next/src/app/(dashboard)/dashboardcoord/_components/DemandaCard.tsx
+++ b/clarify-next/src/app/(dashboard)/dashboardcoord/_components/DemandaCard.tsx
@@ -20,6 +20,9 @@ export function DemandaCard({ demanda: d, onVerDetalhes, onAprovar, onReprovar }
         <div className="flex items-start justify-between gap-4 mb-4">
           <div className="min-w-0 space-y-2">
             <h3 className="text-lg font-semibold text-gray-900 truncate">{d.tipo}</h3>
+            {d.aluno?.nome && (
+              <p className="text-sm text-gray-600 font-medium">{d.aluno.nome}</p>
+            )}
             <p className="text-sm text-gray-500 line-clamp-2">{d.descricao}</p>
           </div>
           <span className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold shrink-0 ${

--- a/clarify-next/src/app/(dashboard)/dashboardcoord/page.tsx
+++ b/clarify-next/src/app/(dashboard)/dashboardcoord/page.tsx
@@ -53,8 +53,11 @@ export default function DashboardCoordPage() {
   const alunoIds = useMemo(() => new Set(alunosDoCoord.map((a) => a.id)), [alunosDoCoord]);
 
   const demandasDoCoord = useMemo(
-    () => demandas.filter((d) => alunoIds.has(d.alunoId)),
-    [alunoIds, demandas]
+    () => demandas.filter((d) => alunoIds.has(d.alunoId)).map(d => ({
+      ...d,
+      aluno: alunosDoCoord.find(a => a.id === d.alunoId)
+    })),
+    [alunoIds, demandas, alunosDoCoord]
   );
 
   const demandasPendentes = useMemo(

--- a/clarify-next/src/components/demandas/CardDemanda.tsx
+++ b/clarify-next/src/components/demandas/CardDemanda.tsx
@@ -34,6 +34,9 @@ export function CardDemanda({ demanda, onVerDetalhes }: CardDemandaProps) {
         <h3 className="text-base font-bold text-gray-900 break-words [overflow-wrap:anywhere]">
           {demanda.tipo}
         </h3>
+        {demanda.aluno?.nome && (
+          <p className="text-sm text-gray-600 font-medium mt-1">{demanda.aluno.nome}</p>
+        )}
         <p className="text-sm text-gray-600 mt-1 line-clamp-2 break-words [overflow-wrap:anywhere]">
           {demanda.descricao}
         </p>

--- a/clarify-next/src/types/index.ts
+++ b/clarify-next/src/types/index.ts
@@ -54,6 +54,7 @@ export interface Demanda {
   dataCriacao: string;
   dataAtualizacao: string;
   feedback: string;
+  aluno?: { nome: string; matricula: string };
 }
 
 /**


### PR DESCRIPTION
📝 Resumo
Exibe o nome do aluno no card de demanda do coordenador para identificação rápida sem precisar abrir o modal de detalhes.

💡 Por que
O coordenador não via de quem era a demanda no card — precisava abrir o modal de detalhes para descobrir o aluno. Isso atrapalhava a triagem rápida. Atende o critério de aceitação CA05.

🛠️ O que mudou
- Adiciona campo aluno?: { nome: string; matricula: string } na interface Demanda (src/types/index.ts)
- Enriquece demandasDoCoord com join dos dados do aluno (src/app/(dashboard)/dashboardcoord/page.tsx)
- Exibe o nome do aluno no DemandaCard do coordenador (_components/DemandaCard.tsx)
- Exibe o nome do aluno no CardDemanda genérico (src/components/demandas/CardDemanda.tsx)

🧪 Como testar
1. npm run dev
2. Logar como coordenador
3. Acessar /dashboardcoord?view=demandas
4. Verificar se o nome do aluno aparece no card, entre o título (tipo da demanda) e a descrição

✅ Checklist
- Rodei npm run dev e testei no navegador
- Rodei npx tsc --noEmit e não deu erro
- Não tem console.log ou comentário esquecido
- Os imports não utilizados foram removidos
- Se mexi em algo do design system, conferi se outras telas continuam funcionando