### PR TITLE
feat(demandas): campos dinâmicos, feedback contado e ordenação por expiração

### DIFF
--- a/clarify-next/src/app/(dashboard)/centraldemandas/page.tsx
+++ b/clarify-next/src/app/(dashboard)/centraldemandas/page.tsx
@@ -17,6 +17,7 @@ import { useDemandas } from '@/hooks/useDemandas';
 import { usePerfil } from '@/hooks/usePerfil';
 import { useTurmas } from '@/hooks/useTurmas';
 import { useAuth } from '@/context/AuthContext';
+import { dataExpiracao } from '@/lib/utils';
 import { useFiltrosStore } from '@/store/filtrosStore';
 import { useUIStore } from '@/store/uiStore';
 import type { TipoDemanda } from '@/types';
@@ -62,7 +63,12 @@ export default function CentralDemandasPage() {
     });
   }, [demandas, busca, filtroStatus]);
 
-  const emAberto = useMemo(() => filtradas.filter((d) => d.status !== 'concluido'), [filtradas]);
+  const emAberto = useMemo(
+    () => filtradas
+      .filter((d) => d.status !== 'concluido')
+      .toSorted((a, b) => dataExpiracao(a).getTime() - dataExpiracao(b).getTime()),
+    [filtradas]
+  );
   const concluidas = useMemo(() => filtradas.filter((d) => d.status === 'concluido'), [filtradas]);
 
   const total = demandas.length;

--- a/clarify-next/src/app/(dashboard)/centraldemandas/page.tsx
+++ b/clarify-next/src/app/(dashboard)/centraldemandas/page.tsx
@@ -71,11 +71,12 @@ export default function CentralDemandasPage() {
   const resolvidas = demandas.filter((d) => d.status === 'concluido').length;
   const eficiencia = total > 0 ? Math.round((resolvidas / total) * 100) : 0;
 
-  const handleCriarDemanda = useCallback((dados: { tipo: TipoDemanda; descricao: string }) => {
+  const handleCriarDemanda = useCallback((dados: { tipo: TipoDemanda; descricao: string; camposExtras: Record<string, string> }) => {
     if (!usuario?.id) return;
     criar({
       tipo: dados.tipo,
       descricao: dados.descricao,
+      camposExtras: dados.camposExtras,
     });
   }, [criar, usuario]);
 

--- a/clarify-next/src/app/(dashboard)/centraldemandas/page.tsx
+++ b/clarify-next/src/app/(dashboard)/centraldemandas/page.tsx
@@ -77,9 +77,9 @@ export default function CentralDemandasPage() {
   const resolvidas = demandas.filter((d) => d.status === 'concluido').length;
   const eficiencia = total > 0 ? Math.round((resolvidas / total) * 100) : 0;
 
-  const handleCriarDemanda = useCallback((dados: { tipo: TipoDemanda; descricao: string; camposExtras: Record<string, string> }) => {
+  const handleCriarDemanda = useCallback(async (dados: { tipo: TipoDemanda; descricao: string; camposExtras: Record<string, string> }) => {
     if (!usuario?.id) return;
-    criar({
+    await criar({
       tipo: dados.tipo,
       descricao: dados.descricao,
       camposExtras: dados.camposExtras,

--- a/clarify-next/src/app/api/demandas/route.ts
+++ b/clarify-next/src/app/api/demandas/route.ts
@@ -1,5 +1,6 @@
 import { createAdminClient } from '@/lib/supabase/admin'
 import { createClient } from '@/lib/supabase/server'
+import { montarCamposExtras } from '@/lib/camposDemanda'
 import { novaDemandaSchema } from '@/schemas/demandas'
 import { NextResponse } from 'next/server'
 
@@ -74,6 +75,7 @@ export async function POST(request: Request) {
       aluno_id: user.id,
       tipo: validacao.data.tipo,
       descricao: validacao.data.descricao,
+      campos_extras: montarCamposExtras(validacao.data.tipo, validacao.data.camposExtras),
     })
     .select()
     .single()

--- a/clarify-next/src/app/api/demandas/route.ts
+++ b/clarify-next/src/app/api/demandas/route.ts
@@ -38,8 +38,15 @@ export async function POST(request: Request) {
     )
   }
 
-  const { data: { user } } = await supabase.auth.getUser()
+  const getUserResult = await supabase.auth.getUser()
+  const user = getUserResult.data?.user
   if (!user) {
+    const sessionResult = await supabase.auth.getSession()
+    console.error('[POST /api/demandas] auth fail', {
+      getUserError: getUserResult.error?.message,
+      hasSession: !!sessionResult.data?.session,
+      sessionError: sessionResult.error?.message,
+    })
     return NextResponse.json(
       { ok: false, mensagem: 'Não autorizado.' },
       { status: 401 },

--- a/clarify-next/src/components/coordenador/ModalFeedback.tsx
+++ b/clarify-next/src/components/coordenador/ModalFeedback.tsx
@@ -14,7 +14,10 @@ interface ModalFeedbackProps {
   onSubmit: (feedback: string) => void;
 }
 
+const LIMITE_FEEDBACK = 200;
+
 const labelClass = "text-[0.6875rem] font-bold tracking-[0.18em] uppercase text-[rgba(15,23,42,0.45)]";
+const counterClass = "tabular-nums text-[0.6875rem] text-[rgba(15,23,42,0.40)] tracking-[0.04em]";
 const inputClass = "w-full bg-transparent border-0 border-b-[1.5px] border-[rgba(15,23,42,0.10)] py-2 px-0 text-lg leading-[1.3] -tracking-[0.01em] text-[#0f172a] placeholder:text-[rgba(15,23,42,0.30)] placeholder:font-normal focus:outline-none focus:border-b-[#ca5f15] transition-[border-color] duration-180";
 const btnPrimaryClass = "inline-flex items-center gap-2 bg-[#ca5f15] text-white font-bold text-sm -tracking-[0.005em] py-3 px-5 rounded-xl shadow-[inset_0_1px_0_rgba(255,255,255,0.18),_0_1px_2px_rgba(202,95,21,0.30),_0_10px_24px_-10px_rgba(202,95,21,0.55)] hover:bg-[#b35211] hover:-translate-y-px active:translate-y-0 disabled:bg-[rgba(15,23,42,0.10)] disabled:text-[rgba(15,23,42,0.35)] disabled:shadow-none disabled:cursor-not-allowed disabled:transform-none transition-[transform,box-shadow,background-color] duration-180 cursor-pointer";
 const btnGhostClass = "inline-flex items-center gap-1.5 bg-transparent text-[rgba(15,23,42,0.65)] font-semibold text-sm py-3 px-4 rounded-xl hover:bg-[rgba(15,23,42,0.05)] hover:text-[#0f172a] transition-[background-color,color] duration-180 cursor-pointer";
@@ -23,12 +26,18 @@ export function ModalFeedback({ open, onClose, onSubmit }: ModalFeedbackProps) {
   const {
     register,
     handleSubmit,
+    watch,
     reset,
     formState: { errors },
   } = useForm<FeedbackFormData>({
     resolver: zodResolver(feedbackSchema),
     mode: 'onChange',
   });
+
+  const textoValue = watch('texto') ?? '';
+
+  const contadorNear = textoValue.length >= LIMITE_FEEDBACK * 0.85 && textoValue.length < LIMITE_FEEDBACK;
+  const contadorOver = textoValue.length >= LIMITE_FEEDBACK;
 
   const onValid = useCallback((data: FeedbackFormData) => {
     onSubmit(data.texto.trim());
@@ -61,11 +70,17 @@ export function ModalFeedback({ open, onClose, onSubmit }: ModalFeedbackProps) {
 
           <form onSubmit={handleSubmit(onValid)} className="space-y-5">
             <div>
-              <label htmlFor="campoFeedback" className={labelClass}>Feedback</label>
+              <div className="flex items-end justify-between gap-3">
+                <label htmlFor="campoFeedback" className={labelClass}>Feedback</label>
+                <span className={cn(counterClass, contadorNear && "text-[#d97706]", contadorOver && "text-[#dc2626]")}>
+                  {textoValue.length} / {LIMITE_FEEDBACK}
+                </span>
+              </div>
               <input
                 id="campoFeedback"
                 type="text"
                 {...register('texto')}
+                maxLength={LIMITE_FEEDBACK}
                 placeholder="Digite seu feedback..."
                 className={cn(inputClass, "font-semibold mt-1")}
               />

--- a/clarify-next/src/components/demandas/CardDemanda.tsx
+++ b/clarify-next/src/components/demandas/CardDemanda.tsx
@@ -3,7 +3,7 @@
 import { Calendar, Clock, ChevronRight } from 'lucide-react';
 import { Card } from '@/components/ui/Card';
 import { Badge } from '@/components/ui/Badge';
-import { obterLabelStatus, formatarData } from '@/lib/utils';
+import { obterLabelStatus, formatarData, diasParaExpirar, pertoDaExpiracao } from '@/lib/utils';
 import type { Demanda, StatusDemanda } from '@/types';
 
 const statusVariant: Record<StatusDemanda, 'pendente' | 'em_analise' | 'requer_ajuste' | 'concluido'> = {
@@ -19,15 +19,25 @@ interface CardDemandaProps {
 }
 
 export function CardDemanda({ demanda, onVerDetalhes }: CardDemandaProps) {
+  const alerta = pertoDaExpiracao(demanda);
+  const diasRestantes = diasParaExpirar(demanda);
+
   return (
     <Card className="p-4 sm:p-5 flex flex-col gap-3 hover:shadow-md hover:-translate-y-0.5 transition-all">
       <div className="flex items-center justify-between gap-2">
         <span className="text-xs font-semibold text-gray-500 tracking-wider">
           #{demanda.protocolo}
         </span>
-        <Badge variant={statusVariant[demanda.status]}>
-          {obterLabelStatus(demanda.status)}
-        </Badge>
+        <div className="flex items-center gap-2">
+          {alerta && (
+            <Badge variant="orange">
+              {diasRestantes > 0 ? `Vence em ${diasRestantes}d` : 'Vencida'}
+            </Badge>
+          )}
+          <Badge variant={statusVariant[demanda.status]}>
+            {obterLabelStatus(demanda.status)}
+          </Badge>
+        </div>
       </div>
 
       <div className="min-w-0">

--- a/clarify-next/src/components/demandas/ModalNovaDemanda.tsx
+++ b/clarify-next/src/components/demandas/ModalNovaDemanda.tsx
@@ -7,13 +7,14 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { Dialog, DialogContent, DialogHeader, DialogFooter } from '@/components/ui/Dialog';
 import { cn } from '@/lib/utils';
 import { novaDemandaSchema, type NovaDemandaFormData } from '@/schemas/demandas';
+import { CAMPOS_POR_TIPO, montarCamposExtras } from '@/lib/camposDemanda';
 import { TIPOS_DEMANDA, type TipoDemanda, type UsuarioLogado } from '@/types';
 
 interface ModalNovaDemandaProps {
   open: boolean;
   onClose: () => void;
   usuario: UsuarioLogado | null;
-  onSubmit: (dados: { tipo: TipoDemanda; descricao: string }) => void;
+  onSubmit: (dados: { tipo: TipoDemanda; descricao: string; camposExtras: Record<string, string> }) => void;
 }
 
 const LIMITE_DESCRICAO = 500;
@@ -31,13 +32,15 @@ export function ModalNovaDemanda({ open, onClose, usuario, onSubmit }: ModalNova
   });
 
   const descricaoValue = watch('descricao') ?? '';
+  const camposDoTipo = CAMPOS_POR_TIPO[watch('tipo')] ?? [];
 
   const contadorNear = descricaoValue.length >= LIMITE_DESCRICAO * 0.85 && descricaoValue.length < LIMITE_DESCRICAO;
   const contadorOver = descricaoValue.length >= LIMITE_DESCRICAO;
 
   const onValid = useCallback((data: NovaDemandaFormData) => {
     if (!usuario?.matricula) return;
-    onSubmit({ tipo: data.tipo, descricao: data.descricao.trim() });
+    const camposExtras = montarCamposExtras(data.tipo, data.camposExtras);
+    onSubmit({ tipo: data.tipo, descricao: data.descricao.trim(), camposExtras });
     reset();
     onClose();
   }, [usuario, onSubmit, reset, onClose]);
@@ -101,6 +104,33 @@ export function ModalNovaDemanda({ open, onClose, usuario, onSubmit }: ModalNova
                 <p className="text-xs text-red-600 mt-1">{errors.tipo.message}</p>
               )}
             </section>
+
+            {camposDoTipo.map((campo) => {
+              const erro = errors.camposExtras?.[campo.name]?.message;
+              return (
+                <section key={campo.name} className="mt-5">
+                  <label htmlFor={`campo-${campo.name}`} className={labelClass}>{campo.label}</label>
+                  {campo.type === 'textarea' ? (
+                    <textarea
+                      id={`campo-${campo.name}`}
+                      {...register(`camposExtras.${campo.name}`)}
+                      rows={3}
+                      placeholder={campo.placeholder}
+                      className={cn(textareaClass, 'mt-2')}
+                    />
+                  ) : (
+                    <input
+                      id={`campo-${campo.name}`}
+                      type={campo.type}
+                      {...register(`camposExtras.${campo.name}`)}
+                      placeholder={campo.placeholder}
+                      className={cn(inputClass, 'mt-1')}
+                    />
+                  )}
+                  {erro && <p className="text-xs text-red-600 mt-1">{erro}</p>}
+                </section>
+              );
+            })}
 
             <section className="mt-5">
               <div className="flex items-end justify-between gap-3">

--- a/clarify-next/src/components/demandas/ModalNovaDemanda.tsx
+++ b/clarify-next/src/components/demandas/ModalNovaDemanda.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import { ArrowRight, X } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -14,7 +14,7 @@ interface ModalNovaDemandaProps {
   open: boolean;
   onClose: () => void;
   usuario: UsuarioLogado | null;
-  onSubmit: (dados: { tipo: TipoDemanda; descricao: string; camposExtras: Record<string, string> }) => void;
+  onSubmit: (dados: { tipo: TipoDemanda; descricao: string; camposExtras: Record<string, string> }) => Promise<void>;
 }
 
 const LIMITE_DESCRICAO = 500;
@@ -31,18 +31,29 @@ export function ModalNovaDemanda({ open, onClose, usuario, onSubmit }: ModalNova
     mode: 'onChange',
   });
 
+  const [submitting, setSubmitting] = useState(false);
+  const [erroSubmit, setErroSubmit] = useState<string | null>(null);
+
   const descricaoValue = watch('descricao') ?? '';
   const camposDoTipo = CAMPOS_POR_TIPO[watch('tipo')] ?? [];
 
   const contadorNear = descricaoValue.length >= LIMITE_DESCRICAO * 0.85 && descricaoValue.length < LIMITE_DESCRICAO;
   const contadorOver = descricaoValue.length >= LIMITE_DESCRICAO;
 
-  const onValid = useCallback((data: NovaDemandaFormData) => {
+  const onValid = useCallback(async (data: NovaDemandaFormData) => {
     if (!usuario?.matricula) return;
-    const camposExtras = montarCamposExtras(data.tipo, data.camposExtras);
-    onSubmit({ tipo: data.tipo, descricao: data.descricao.trim(), camposExtras });
-    reset();
-    onClose();
+    setSubmitting(true);
+    setErroSubmit(null);
+    try {
+      const camposExtras = montarCamposExtras(data.tipo, data.camposExtras);
+      await onSubmit({ tipo: data.tipo, descricao: data.descricao.trim(), camposExtras });
+      reset();
+      onClose();
+    } catch (err) {
+      setErroSubmit(err instanceof Error ? err.message : 'Erro inesperado. Tente novamente.');
+    } finally {
+      setSubmitting(false);
+    }
   }, [usuario, onSubmit, reset, onClose]);
 
   const handleClose = useCallback(() => {
@@ -152,6 +163,12 @@ export function ModalNovaDemanda({ open, onClose, usuario, onSubmit }: ModalNova
               )}
             </section>
 
+            {erroSubmit && (
+              <section className="mt-5 rounded-2xl bg-red-50 border border-red-200 px-4 py-3">
+                <p className="text-sm text-red-700">{erroSubmit}</p>
+              </section>
+            )}
+
             <section className="mt-5 flex items-center gap-3 bg-brand-surface rounded-2xl px-3.5 py-2.5 border border-gray-100">
               <div className="w-8 h-8 rounded-full bg-brand-primary text-white text-xs font-bold flex items-center justify-center shrink-0">
                 {inicial}
@@ -170,10 +187,10 @@ export function ModalNovaDemanda({ open, onClose, usuario, onSubmit }: ModalNova
             <button type="button" className={btnGhostClass} onClick={handleClose}>
               Cancelar
             </button>
-            <button type="submit" className={btnPrimaryClass}>
-              Enviar solicitação
-              <ArrowRight className="w-4 h-4" />
-            </button>
+            <button type="submit" className={btnPrimaryClass} disabled={submitting}>
+                {submitting ? 'Enviando...' : 'Enviar solicitação'}
+                {!submitting && <ArrowRight className="w-4 h-4" />}
+              </button>
           </DialogFooter>
         </form>
       </DialogContent>

--- a/clarify-next/src/hooks/useDemandas.ts
+++ b/clarify-next/src/hooks/useDemandas.ts
@@ -40,7 +40,7 @@ export function useDemandas(opcoes?: UseDemandasOptions) {
   })
 
   const criarMutation = useMutation({
-    mutationFn: async (dados: { tipo: TipoDemanda; descricao: string }) => {
+    mutationFn: async (dados: { tipo: TipoDemanda; descricao: string; camposExtras?: Record<string, string> }) => {
       const res = await fetch('/api/demandas', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/clarify-next/src/hooks/useDemandas.ts
+++ b/clarify-next/src/hooks/useDemandas.ts
@@ -47,7 +47,9 @@ export function useDemandas(opcoes?: UseDemandasOptions) {
         body: JSON.stringify(dados),
       })
       const json = await res.json()
-      if (!json.ok || !json.data) return null
+      if (!json.ok || !json.data) {
+        throw new Error(json.mensagem || 'Erro ao criar demanda.')
+      }
       return mapRow(json.data) as Demanda
     },
     onSuccess: () => {

--- a/clarify-next/src/lib/camposDemanda.ts
+++ b/clarify-next/src/lib/camposDemanda.ts
@@ -1,0 +1,46 @@
+import type { TipoDemanda } from '@/types'
+
+export type CampoExtra = {
+  name: string
+  label: string
+  type: 'text' | 'date' | 'number' | 'textarea'
+  placeholder?: string
+}
+
+export function montarCamposExtras(
+  tipo: TipoDemanda,
+  valores: Record<string, string> | undefined,
+): Record<string, string> {
+  return Object.fromEntries(
+    (CAMPOS_POR_TIPO[tipo] ?? []).map((campo) => [campo.name, (valores?.[campo.name] ?? '').trim()]),
+  )
+}
+
+export const CAMPOS_POR_TIPO: Partial<Record<TipoDemanda, CampoExtra[]>> = {
+  'Quebra de Pré-requisito': [
+    { name: 'disciplinaAlvo', label: 'Disciplina alvo', type: 'text', placeholder: 'Disciplina cujo pré-requisito será quebrado' },
+  ],
+  'Revisão de Prova': [
+    { name: 'disciplina', label: 'Disciplina', type: 'text' },
+    { name: 'dataProva', label: 'Data da prova', type: 'date' },
+  ],
+  'Aproveitamento de Horas AC': [
+    { name: 'cargaHoraria', label: 'Carga horária (horas)', type: 'number', placeholder: 'Ex.: 20' },
+    { name: 'atividade', label: 'Atividade realizada', type: 'textarea', placeholder: 'Descreva a atividade complementar' },
+  ],
+  'Trancamento de Disciplina': [
+    { name: 'disciplina', label: 'Disciplina', type: 'text' },
+  ],
+  'Troca de Turma': [
+    { name: 'turmaOrigem', label: 'Turma de origem', type: 'text' },
+    { name: 'turmaDestino', label: 'Turma de destino', type: 'text' },
+  ],
+  'Solicitação de Histórico': [
+    { name: 'periodo', label: 'Período desejado', type: 'text', placeholder: 'Ex.: 2025.1' },
+  ],
+  'Justificativa de Falta': [
+    { name: 'disciplina', label: 'Disciplina', type: 'text' },
+    { name: 'datas', label: 'Data(s) da falta', type: 'text', placeholder: 'Separe múltiplas datas por vírgula' },
+    { name: 'motivo', label: 'Motivo', type: 'textarea' },
+  ],
+}

--- a/clarify-next/src/lib/utils.ts
+++ b/clarify-next/src/lib/utils.ts
@@ -3,7 +3,7 @@
 // Funções utilitárias genéricas
 // ═════════════════════════════════════════════════════════════════
 
-import type { StatusDemanda } from '@/types';
+import type { Demanda, StatusDemanda } from '@/types';
 
 // Formata uma data ISO ("2025-11-12") para "12 Nov 2025"
 export function formatarData(dataISO: string): string {
@@ -59,6 +59,28 @@ export function obterCorStatus(status: StatusDemanda): string {
     concluido: 'bg-green-100 text-green-800',
   };
   return cores[status];
+}
+
+// SLA de atendimento de uma demanda, em dias a partir da criação. Calibrar conforme a realidade.
+export const PRAZO_DIAS = 30;
+// Janela final em que a demanda passa a ser sinalizada como perto do prazo.
+export const LIMITE_ALERTA_DIAS = 7;
+
+// Data de expiração derivada: criação + PRAZO_DIAS.
+export function dataExpiracao(demanda: Demanda): Date {
+  const data = new Date(demanda.dataCriacao);
+  data.setDate(data.getDate() + PRAZO_DIAS);
+  return data;
+}
+
+// Dias restantes até expirar (negativo quando já venceu).
+export function diasParaExpirar(demanda: Demanda): number {
+  return Math.ceil((dataExpiracao(demanda).getTime() - Date.now()) / 86400000);
+}
+
+// Demanda em aberto e dentro da janela de alerta.
+export function pertoDaExpiracao(demanda: Demanda): boolean {
+  return demanda.status !== 'concluido' && diasParaExpirar(demanda) <= LIMITE_ALERTA_DIAS;
 }
 
 // Concatena classes CSS (similar a clsx/classnames)

--- a/clarify-next/src/schemas/demandas.ts
+++ b/clarify-next/src/schemas/demandas.ts
@@ -1,15 +1,29 @@
 import { z } from 'zod'
 import { TIPOS_DEMANDA } from '@/types'
+import { CAMPOS_POR_TIPO } from '@/lib/camposDemanda'
 
 export const tipoDemandaSchema = z.enum(TIPOS_DEMANDA, 'Selecione o tipo de solicitação.')
 
-export const novaDemandaSchema = z.object({
-  tipo: tipoDemandaSchema,
-  descricao: z
-    .string()
-    .min(10, 'Descrição deve ter no mínimo 10 caracteres.')
-    .max(500, 'Descrição deve ter no máximo 500 caracteres.'),
-})
+export const novaDemandaSchema = z
+  .object({
+    tipo: tipoDemandaSchema,
+    descricao: z
+      .string()
+      .min(10, 'Descrição deve ter no mínimo 10 caracteres.')
+      .max(500, 'Descrição deve ter no máximo 500 caracteres.'),
+    camposExtras: z.record(z.string(), z.string()).optional(),
+  })
+  .superRefine((data, ctx) => {
+    for (const campo of CAMPOS_POR_TIPO[data.tipo] ?? []) {
+      if (!data.camposExtras?.[campo.name]?.trim()) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['camposExtras', campo.name],
+          message: `${campo.label} é obrigatório.`,
+        })
+      }
+    }
+  })
 
 export type NovaDemandaFormData = z.infer<typeof novaDemandaSchema>
 

--- a/clarify-next/src/schemas/demandas.ts
+++ b/clarify-next/src/schemas/demandas.ts
@@ -16,7 +16,8 @@ export type NovaDemandaFormData = z.infer<typeof novaDemandaSchema>
 export const feedbackSchema = z.object({
   texto: z
     .string()
-    .min(5, 'Feedback deve ter no mínimo 5 caracteres.'),
+    .min(5, 'Feedback deve ter no mínimo 5 caracteres.')
+    .max(200, 'Feedback deve ter no máximo 200 caracteres.'),
 })
 
 export type FeedbackFormData = z.infer<typeof feedbackSchema>

--- a/clarify-next/supabase/migrations/20260630000000_add_campos_extras_demandas.sql
+++ b/clarify-next/supabase/migrations/20260630000000_add_campos_extras_demandas.sql
@@ -1,0 +1,2 @@
+alter table public.demandas
+  add column if not exists campos_extras jsonb not null default '{}'::jsonb;


### PR DESCRIPTION
Consolida três frentes da feature de demandas (ENZ-47 e CAs relacionados), todas baseadas em `develop` e revisadas. **12 tickets**, merge limpo entre os clusters.

## Clusters

### A — Campos dinâmicos por tipo (`ENZ-181`..`ENZ-188`)
Motor config-driven: `CAMPOS_POR_TIPO` (em `lib/camposDemanda.ts`) define os campos extras de cada tipo de demanda. O modal renderiza os campos do tipo selecionado, o zod valida os obrigatórios via `superRefine`, e os valores são persistidos numa coluna nova `campos_extras` (jsonb). A poda dos campos por tipo é um helper único compartilhado entre cliente e servidor (fecha o furo de whitelist no trust boundary).

- `ENZ-180` e `ENZ-124` (dropdown + enum) já estavam prontos na `develop` — não recriados.

### C — Feedback do coordenador contado (`ENZ-120`, `ENZ-121`)
Limite de 200 caracteres no `feedbackSchema` + contador inline de caracteres usados/restantes no `ModalFeedback`, replicando o padrão já existente da descrição (sem nova abstração).

### D — Ordenação e alerta por expiração (`ENZ-107`, `ENZ-108`)
Expiração **derivada** (sem coluna no banco): `data_criacao + PRAZO_DIAS`. Constantes calibráveis (`PRAZO_DIAS=30`, `LIMITE_ALERTA_DIAS=7`) e helpers em `lib/utils.ts`. Lista de demandas em aberto ordenada por expiração (mais urgente primeiro) e badge "Vence em Xd"/"Vencida" no card (oculto para concluídas).

## ⚠️ Migration
Aplicar antes do deploy: `supabase/migrations/20260630000000_add_campos_extras_demandas.sql` (adiciona `campos_extras jsonb not null default '{}'`).

## Verificação
- `tsc --noEmit`: zero erros novos (os pré-existentes são `@radix-ui/react-dialog` não instalado, idênticos na `develop`).
- `eslint`: limpo nos arquivos tocados (só o warning `react-hooks/incompatible-library` do RHF, já presente na base).
- Cluster A revisado por 3 agentes paralelos (correção/data-flow, convenção/a11y, zod-v4/typing); C e D revisados manualmente. Os 3 clusters fazem merge limpo entre si.

## Fora de escopo (proposital)
- Exibir os `campos_extras` no detalhe da demanda → é `ENZ-70`.
- Picker multi-data na Justificativa de Falta → campo texto por ora.
