### PR TITLE
feat(coordenador): demanda pendente vira 'em análise' no primeiro acesso

### DIFF
--- a/clarify-next/src/app/(dashboard)/dashboardcoord/page.tsx
+++ b/clarify-next/src/app/(dashboard)/dashboardcoord/page.tsx
@@ -30,7 +30,7 @@ const VIEWS: DashView[] = ['nome', 'alunos', 'demandas', 'turmas', 'adicionar', 
 export default function DashboardCoordPage() {
   const queryClient = useQueryClient();
   const { usuario } = useAuth();
-  const { demandas, recarregar: recarregarDemandas } = useDemandas();
+  const { demandas, recarregar: recarregarDemandas, atualizarStatus } = useDemandas();
   const usuariosHook = useUsuarios();
   const turmasHook = useTurmas();
   const { chaves, loading: chavesLoading, gerar: gerarChave, gerando: gerandoChave, ultimaGerada } = useChaves();
@@ -116,7 +116,10 @@ export default function DashboardCoordPage() {
     setDemandaDetalhe(demanda);
     setRemetenteDetalhe(remetente);
     setModalDetalhesAberta(true);
-  }, [demandas, alunosDoCoord, setDemandaDetalhe, setRemetenteDetalhe, setModalDetalhesAberta]);
+    if (demanda?.status === 'pendente') {
+      atualizarStatus(protocolo, 'em_analise');
+    }
+  }, [demandas, alunosDoCoord, atualizarStatus, setDemandaDetalhe, setRemetenteDetalhe, setModalDetalhesAberta]);
 
   const handleFeedbackSubmit = useCallback(async (feedback: string) => {
     if (!protocoloFeedback) return;


### PR DESCRIPTION
Quando a coordenação abre uma demanda com status `pendente`, ela passa automaticamente para `em_analise` (ENZ-116 / CA06).

Reusa a mutation `atualizarStatus` que já existe no `useDemandas` (update otimista — o card reflete na hora). Guard em `status === 'pendente'`: não rebaixa, não re-dispara ao reabrir, e não toca nos demais status. Só dispara no lado coordenador; o fluxo do aluno fica intocado.

**Arquivo:** `src/app/(dashboard)/dashboardcoord/page.tsx` (+5/-2)

Fecha ENZ-116.

## Verificação (build real)
Repo com deps instaladas: `npm ci` limpo, `tsc --noEmit` **0 erros** no projeto todo, e `next build` **passa** (com env dummy do Supabase). Integra sem conflito com os outros PRs.

## Como testar
1. Subir o app com env do Supabase e logar como **coordenador**.
2. Ter (ou semear) uma demanda em status **"pendente"**.
3. No dashboard do coordenador, abrir os detalhes dessa demanda (clicar no card).
4. Conferir que o status vira **"em análise"** na hora (card otimista) e persiste no banco.
5. Fechar e reabrir a mesma demanda → não muda de novo, não re-dispara.
6. Abrir uma demanda **em análise / requer ajuste / concluída** → status **não** muda.
7. Como **aluno**, abrir detalhes → status **não** muda (só coordenador dispara).

## O que testar
- [ ] "pendente" → "em análise" apenas no primeiro acesso do coordenador.
- [ ] Guard não rebaixa status já avançado nem re-dispara ao reabrir.
- [ ] Persistência: recarregar a página mantém "em análise".
- [ ] Lado aluno não altera status.
- [ ] Update otimista reflete no card na hora (e reverte se a API falhar).
