### PR TITLE
feat(perfil): página de perfil — dados, telefone e troca de senha

### DIFF
--- a/clarify-next/src/app/(dashboard)/perfil/page.tsx
+++ b/clarify-next/src/app/(dashboard)/perfil/page.tsx
@@ -1,0 +1,240 @@
+'use client'
+
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { Eye, EyeOff, Save, KeyRound, AlertCircle } from 'lucide-react'
+import { useAuth } from '@/context/AuthContext'
+import { usePerfil } from '@/hooks/usePerfil'
+import { createClient } from '@/lib/supabase/client'
+import { Card } from '@/components/ui/Card'
+import { cn } from '@/lib/utils'
+import {
+  perfilSchema,
+  type PerfilFormData,
+  senhaSchema,
+  type SenhaFormData,
+} from '@/schemas/perfil'
+import type { Cargo } from '@/types'
+
+const labelClass = "text-[0.6875rem] font-bold tracking-[0.18em] uppercase text-[rgba(15,23,42,0.45)]"
+const inputClass = "w-full bg-transparent border-0 border-b-[1.5px] border-[rgba(15,23,42,0.10)] py-2 px-0 text-lg leading-[1.3] -tracking-[0.01em] text-[#0f172a] placeholder:text-[rgba(15,23,42,0.30)] placeholder:font-normal focus:outline-none focus:border-b-[#ca5f15] transition-[border-color] duration-180"
+const dotClass = "inline-block w-1.5 h-1.5 rounded-full bg-[#ca5f15] shadow-[0_0_0_3px_rgba(202,95,21,0.18)]"
+const btnPrimaryClass = "inline-flex items-center gap-2 bg-[#ca5f15] text-white font-bold text-sm -tracking-[0.005em] py-3 px-5 rounded-xl shadow-[inset_0_1px_0_rgba(255,255,255,0.18),_0_1px_2px_rgba(202,95,21,0.30),_0_10px_24px_-10px_rgba(202,95,21,0.55)] hover:bg-[#b35211] hover:-translate-y-px active:translate-y-0 disabled:bg-[rgba(15,23,42,0.10)] disabled:text-[rgba(15,23,42,0.35)] disabled:shadow-none disabled:cursor-not-allowed disabled:transform-none transition-[transform,box-shadow,background-color] duration-180 cursor-pointer"
+
+const CARGO_LABEL: Record<Cargo, string> = { aluno: 'Aluno', coordenador: 'Coordenador' }
+
+type Mensagem = { ok: boolean; texto: string } | null
+
+function Feedback({ msg }: { msg: Mensagem }) {
+  if (!msg) return null
+  return (
+    <div
+      className={cn(
+        'inline-flex items-start gap-2 text-xs font-semibold rounded-lg px-3 py-2 border',
+        msg.ok
+          ? 'text-green-700 bg-green-50 border-green-200'
+          : 'text-rose-700 bg-rose-50 border-rose-200'
+      )}
+    >
+      {!msg.ok && <AlertCircle className="w-4 h-4 mt-px shrink-0" />}
+      <span>{msg.texto}</span>
+    </div>
+  )
+}
+
+function Info({ label, value }: { label: string; value?: string }) {
+  return (
+    <div>
+      <dt className={labelClass}>{label}</dt>
+      <dd className="text-base font-semibold text-gray-900 mt-1 break-words">{value || '—'}</dd>
+    </div>
+  )
+}
+
+export default function PerfilPage() {
+  const { usuario } = useAuth()
+  const { data: perfil, atualizar } = usePerfil(usuario?.id)
+
+  const [dadosMsg, setDadosMsg] = useState<Mensagem>(null)
+  const [senhaMsg, setSenhaMsg] = useState<Mensagem>(null)
+  const [mostrarSenha, setMostrarSenha] = useState(false)
+  const [mostrarConfirma, setMostrarConfirma] = useState(false)
+
+  const dadosForm = useForm<PerfilFormData>({
+    resolver: zodResolver(perfilSchema),
+    mode: 'onBlur',
+    values: { nome: perfil?.nome ?? '', telefone: perfil?.telefone ?? '' },
+    resetOptions: { keepDirtyValues: true },
+  })
+
+  const senhaForm = useForm<SenhaFormData>({
+    resolver: zodResolver(senhaSchema),
+    mode: 'onBlur',
+  })
+
+  async function onSubmitDados(data: PerfilFormData) {
+    setDadosMsg(null)
+    try {
+      await atualizar(data)
+      setDadosMsg({ ok: true, texto: 'Perfil atualizado com sucesso!' })
+    } catch (err) {
+      setDadosMsg({ ok: false, texto: err instanceof Error ? err.message : 'Erro ao atualizar perfil.' })
+    }
+  }
+
+  async function onSubmitSenha(data: SenhaFormData) {
+    setSenhaMsg(null)
+    const supabase = createClient()
+    const { error } = await supabase.auth.updateUser({ password: data.senha })
+    if (error) {
+      setSenhaMsg({ ok: false, texto: error.message })
+    } else {
+      setSenhaMsg({ ok: true, texto: 'Senha alterada com sucesso!' })
+      senhaForm.reset()
+    }
+  }
+
+  return (
+    <>
+      <style>{`
+        input[type="password"]::-ms-reveal,
+        input[type="password"]::-ms-clear,
+        input[type="password"]::-webkit-credentials-auto-fill-button,
+        input[type="password"]::-webkit-textfield-decoration-container {
+          display: none !important;
+        }
+      `}</style>
+      <div className="p-4 sm:p-6 max-w-3xl mx-auto space-y-6">
+        <header className="space-y-1">
+          <h1 className="text-2xl sm:text-3xl font-bold text-gray-900 tracking-tighter-2">Meu Perfil</h1>
+          <p className="text-sm text-gray-500">Gerencie suas informações pessoais e segurança.</p>
+        </header>
+
+        <Card className="p-6 space-y-5">
+          <div className="inline-flex items-center gap-2">
+            <span className={dotClass} />
+            <span className={labelClass}>Informações</span>
+          </div>
+          <dl className="grid grid-cols-1 sm:grid-cols-2 gap-5">
+            <Info label="Nome" value={perfil?.nome} />
+            <Info label="Matrícula" value={perfil?.matricula} />
+            <Info label="E-mail" value={perfil?.email} />
+            <Info label="Cargo" value={perfil ? CARGO_LABEL[perfil.cargo] : ''} />
+            <Info label="Telefone" value={perfil?.telefone} />
+          </dl>
+        </Card>
+
+        <Card className="p-6">
+          <div className="inline-flex items-center gap-2 mb-5">
+            <span className={dotClass} />
+            <span className={labelClass}>Editar dados</span>
+          </div>
+          <form onSubmit={dadosForm.handleSubmit(onSubmitDados)} className="space-y-6">
+            <div>
+              <label htmlFor="perfil-nome" className={labelClass}>Nome Completo</label>
+              <input
+                id="perfil-nome"
+                type="text"
+                {...dadosForm.register('nome')}
+                className={cn(inputClass, 'font-semibold mt-1')}
+                placeholder="Seu nome completo"
+              />
+              {dadosForm.formState.errors.nome && (
+                <p className="text-xs text-red-600 mt-1">{dadosForm.formState.errors.nome.message}</p>
+              )}
+            </div>
+
+            <div>
+              <label htmlFor="perfil-telefone" className={labelClass}>Telefone</label>
+              <input
+                id="perfil-telefone"
+                type="tel"
+                {...dadosForm.register('telefone')}
+                className={cn(inputClass, 'font-semibold mt-1')}
+                placeholder="(00) 00000-0000"
+              />
+              {dadosForm.formState.errors.telefone && (
+                <p className="text-xs text-red-600 mt-1">{dadosForm.formState.errors.telefone.message}</p>
+              )}
+            </div>
+
+            <Feedback msg={dadosMsg} />
+
+            <div className="flex justify-end">
+              <button type="submit" disabled={dadosForm.formState.isSubmitting} className={btnPrimaryClass}>
+                <Save className="w-4 h-4" />
+                Salvar alterações
+              </button>
+            </div>
+          </form>
+        </Card>
+
+        <Card className="p-6">
+          <div className="inline-flex items-center gap-2 mb-5">
+            <span className={dotClass} />
+            <span className={labelClass}>Alterar senha</span>
+          </div>
+          <form onSubmit={senhaForm.handleSubmit(onSubmitSenha)} className="space-y-6">
+            <div>
+              <label htmlFor="perfil-senha" className={labelClass}>Nova senha</label>
+              <div className="relative">
+                <input
+                  id="perfil-senha"
+                  type={mostrarSenha ? 'text' : 'password'}
+                  {...senhaForm.register('senha')}
+                  className={cn(inputClass, 'font-semibold mt-1 pr-8')}
+                  placeholder="••••••••"
+                />
+                <button
+                  type="button"
+                  onClick={() => setMostrarSenha(!mostrarSenha)}
+                  tabIndex={-1}
+                  className="absolute right-0 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 transition-colors"
+                >
+                  {mostrarSenha ? <EyeOff size={20} /> : <Eye size={20} />}
+                </button>
+              </div>
+              {senhaForm.formState.errors.senha && (
+                <p className="text-xs text-red-600 mt-1">{senhaForm.formState.errors.senha.message}</p>
+              )}
+            </div>
+
+            <div>
+              <label htmlFor="perfil-confirma" className={labelClass}>Confirmar nova senha</label>
+              <div className="relative">
+                <input
+                  id="perfil-confirma"
+                  type={mostrarConfirma ? 'text' : 'password'}
+                  {...senhaForm.register('confirmacao')}
+                  className={cn(inputClass, 'font-semibold mt-1 pr-8')}
+                  placeholder="••••••••"
+                />
+                <button
+                  type="button"
+                  onClick={() => setMostrarConfirma(!mostrarConfirma)}
+                  tabIndex={-1}
+                  className="absolute right-0 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 transition-colors"
+                >
+                  {mostrarConfirma ? <EyeOff size={20} /> : <Eye size={20} />}
+                </button>
+              </div>
+              {senhaForm.formState.errors.confirmacao && (
+                <p className="text-xs text-red-600 mt-1">{senhaForm.formState.errors.confirmacao.message}</p>
+              )}
+            </div>
+
+            <Feedback msg={senhaMsg} />
+
+            <div className="flex justify-end">
+              <button type="submit" disabled={senhaForm.formState.isSubmitting} className={btnPrimaryClass}>
+                <KeyRound className="w-4 h-4" />
+                Alterar senha
+              </button>
+            </div>
+          </form>
+        </Card>
+      </div>
+    </>
+  )
+}

--- a/clarify-next/src/app/api/perfis/[id]/route.ts
+++ b/clarify-next/src/app/api/perfis/[id]/route.ts
@@ -1,7 +1,7 @@
 import { createClient } from '@/lib/supabase/server'
 import { NextResponse } from 'next/server'
 
-const ALLOWED_UPDATE_FIELDS = ['coordenador_id', 'nome']
+const ALLOWED_UPDATE_FIELDS = ['coordenador_id', 'nome', 'telefone']
 
 export async function GET(
   _request: Request,

--- a/clarify-next/src/components/layout/UserChip.tsx
+++ b/clarify-next/src/components/layout/UserChip.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link';
 import { LogOut } from 'lucide-react';
 import type { UsuarioLogado } from '@/types';
 
@@ -22,10 +23,15 @@ export function UserChip({ usuario, onLogout, showName = true }: UserChipProps) 
 
   return (
     <div className="flex items-center gap-2 bg-white border border-gray-200 rounded-full pl-2 pr-1 py-1 shadow-sm">
-      {/* Avatar */}
-      <div className="w-8 h-8 rounded-full bg-orange-100 text-orange-600 text-sm font-bold flex items-center justify-center">
+      {/* Avatar (link para o perfil) */}
+      <Link
+        href="/perfil"
+        title="Meu perfil"
+        aria-label="Meu perfil"
+        className="w-8 h-8 rounded-full bg-orange-100 text-orange-600 text-sm font-bold flex items-center justify-center hover:bg-orange-200 transition-colors"
+      >
         {inicial}
-      </div>
+      </Link>
 
       {/* Nome (hidden em LG) */}
       {showName && (

--- a/clarify-next/src/hooks/usePerfil.ts
+++ b/clarify-next/src/hooks/usePerfil.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import type { UsuarioLogado } from '@/types'
 
 function mapProfileToUser(row: Record<string, unknown>): UsuarioLogado {
@@ -10,12 +10,15 @@ function mapProfileToUser(row: Record<string, unknown>): UsuarioLogado {
     matricula: row.matricula as string,
     email: row.email as string,
     cargo: row.cargo as string as UsuarioLogado['cargo'],
+    telefone: (row.telefone as string) ?? undefined,
     coordenador_id: (row.coordenador_id as string) ?? undefined,
   }
 }
 
 export function usePerfil(id: string | null | undefined) {
-  return useQuery({
+  const queryClient = useQueryClient()
+
+  const query = useQuery({
     queryKey: ['perfil', id],
     queryFn: async () => {
       const res = await fetch(`/api/perfis/${id}`)
@@ -25,4 +28,24 @@ export function usePerfil(id: string | null | undefined) {
     },
     enabled: !!id,
   })
+
+  const atualizarMutation = useMutation({
+    mutationFn: async (dados: { nome?: string; telefone?: string }) => {
+      const res = await fetch(`/api/perfis/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(dados),
+      })
+      const json = await res.json()
+      if (!json.ok) {
+        throw new Error(json.mensagem || 'Erro ao atualizar perfil.')
+      }
+      return json
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['perfil', id] })
+    },
+  })
+
+  return { ...query, atualizar: atualizarMutation.mutateAsync }
 }

--- a/clarify-next/src/proxy.ts
+++ b/clarify-next/src/proxy.ts
@@ -34,5 +34,5 @@ export function proxy(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/dashboardcoord/:path*', '/centraldemandas/:path*'],
+  matcher: ['/dashboardcoord/:path*', '/centraldemandas/:path*', '/perfil/:path*'],
 };

--- a/clarify-next/src/schemas/perfil.ts
+++ b/clarify-next/src/schemas/perfil.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod'
+
+export const perfilSchema = z.object({
+  nome: z
+    .string()
+    .min(3, 'Nome deve ter no mínimo 3 caracteres.'),
+  telefone: z
+    .string()
+    .regex(/^[\d\s()+-]*$/, 'Telefone deve conter apenas números.'),
+})
+
+export type PerfilFormData = z.infer<typeof perfilSchema>
+
+export const senhaSchema = z
+  .object({
+    senha: z
+      .string()
+      .min(6, 'Senha deve ter no mínimo 6 caracteres.'),
+    confirmacao: z.string(),
+  })
+  .refine((d) => d.senha === d.confirmacao, {
+    message: 'As senhas não coincidem.',
+    path: ['confirmacao'],
+  })
+
+export type SenhaFormData = z.infer<typeof senhaSchema>

--- a/clarify-next/src/types/index.ts
+++ b/clarify-next/src/types/index.ts
@@ -38,6 +38,7 @@ export type UsuarioLogado = {
   matricula: string;
   email: string;
   cargo: Cargo;
+  telefone?: string;
   coordenador_id?: string;
 };
 

--- a/clarify-next/supabase/migrations/20260701000000_add_telefone_profiles.sql
+++ b/clarify-next/supabase/migrations/20260701000000_add_telefone_profiles.sql
@@ -1,0 +1,2 @@
+-- Adiciona telefone de contato ao perfil (ENZ-38)
+alter table public.profiles add column if not exists telefone text;


### PR DESCRIPTION
Nova página \`/perfil\` (auth-gated, ambos os cargos) que fecha 4 tickets do Módulo de Customização.

## O que entrega
- **ENZ-32** — painel read-only: nome, matrícula, e-mail, cargo, telefone (via \`usePerfil\`/react-query).
- **ENZ-34** — edição do nome → \`PATCH /api/perfis/[id]\` (mutation \`atualizar\` no \`usePerfil\`, invalida o cache). zod \`min(3)\` igual ao registro.
- **ENZ-38** — telefone: migration adiciona a coluna; \`telefone\` entra na allow-list do PATCH, no \`UsuarioLogado\`, no mapeamento do hook e no form/painel.
- **ENZ-36** — troca de senha via \`supabase.auth.updateUser({ password })\` (client nativo), nova senha + confirmação, toggle Eye/EyeOff, zod \`min(6)\` + refine de coincidência, feedback inline.

Link de navegação: avatar do topo (\`UserChip\`) vira \`Link\` para \`/perfil\`.

## ⚠️ Migration
Aplicar antes do deploy: \`supabase/migrations/20260701000000_add_telefone_profiles.sql\` (\`add column if not exists telefone text\`).

## Verificação
- \`tsc --noEmit\`: zero erro novo (só o radix pré-existente). \`eslint\`: limpo nos 7 arquivos tocados.
- Revisado: route PATCH é user-scoped (RLS \`profiles_update_own\` → só edita o próprio registro); matcher do \`/perfil\` exige sessão válida.

## Nota
Após editar o nome, o topo/sidebar (de \`AuthContext\`) fica defasado até recarregar; o painel \`/perfil\` atualiza na hora. Sincronizar o AuthContext exige um método novo de contexto — fora de escopo.

Fecha ENZ-32, ENZ-34, ENZ-36 e ENZ-38.