### PR TITLE
feat: validar e normalizar chave de ativação (maiúsculas + alfanumérico)

### DIFF
--- a/clarify-next/src/app/api/auth/register/route.ts
+++ b/clarify-next/src/app/api/auth/register/route.ts
@@ -2,7 +2,8 @@ import { createAdminClient } from '@/lib/supabase/admin'
 import { NextResponse } from 'next/server'
 
 export async function POST(req: Request) {
-  const { nome, matricula, email, senha, chaveAtivacao } = await req.json()
+  const { nome, matricula, email, senha, chaveAtivacao: chaveAtivacaoRaw } = await req.json()
+  const chaveAtivacao = chaveAtivacaoRaw.toUpperCase()
 
   if (!nome || !matricula || !email || !senha || !chaveAtivacao) {
     return NextResponse.json(

--- a/clarify-next/src/app/registro/page.tsx
+++ b/clarify-next/src/app/registro/page.tsx
@@ -223,7 +223,13 @@ export default function RegistroPage() {
               <input
                 id="registro-activationKey"
                 type="text"
-                {...register('chaveAtivacao')}
+                {...register('chaveAtivacao', {
+                  onChange: (e) => {
+                    const valorUpper = e.target.value.toUpperCase()
+                    const valorLimpo = valorUpper.replace(/[^A-Z0-9]/g, '')
+                    e.target.value = valorLimpo
+                  },
+                })}
                 placeholder="Chave fornecida pela instituição"
                 className="block w-full pl-10 pr-3 py-3 border border-gray-200 rounded-lg bg-gray-50 text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-brand-primary focus:border-transparent transition-all"
                 disabled={isLoading}


### PR DESCRIPTION
This pull request standardizes the handling of the activation key (`chaveAtivacao`) during user registration by ensuring it is always uppercase and contains only alphanumeric characters, both on the frontend and backend.

**Frontend validation and formatting:**

* In `registro/page.tsx`, the activation key input now automatically converts all characters to uppercase and strips out any non-alphanumeric characters as the user types.

**Backend normalization:**

* In `api/auth/register/route.ts`, the backend ensures that the received activation key is converted to uppercase before further processing, providing consistency regardless of client input.