### PR TITLE
feat(tema): dark mode completo (provider, toggle e todas as superfícies)

### DIFF
--- a/clarify-next/src/app/(dashboard)/centraldemandas/_components/ListaMinhasTurmas.tsx
+++ b/clarify-next/src/app/(dashboard)/centraldemandas/_components/ListaMinhasTurmas.tsx
@@ -23,10 +23,10 @@ export function ListaMinhasTurmas({ turmas }: ListaMinhasTurmasProps) {
   if (turmas.length === 0) {
     return (
       <section className="space-y-4">
-        <h2 className="text-xl font-bold text-gray-900">Minhas turmas</h2>
+        <h2 className="text-xl font-bold text-gray-900 dark:text-slate-100">Minhas turmas</h2>
         <Card className="p-8 text-center">
-          <Users className="w-8 h-8 text-gray-300 mx-auto mb-3" />
-          <p className="text-sm text-gray-500">
+          <Users className="w-8 h-8 text-gray-300 dark:text-slate-600 mx-auto mb-3" />
+          <p className="text-sm text-gray-500 dark:text-slate-400">
             Você ainda não está vinculado a nenhuma turma.
           </p>
         </Card>
@@ -37,7 +37,7 @@ export function ListaMinhasTurmas({ turmas }: ListaMinhasTurmasProps) {
   return (
     <section className="space-y-4">
       <div className="flex items-center justify-between">
-        <h2 className="text-xl font-bold text-gray-900">Minhas turmas</h2>
+        <h2 className="text-xl font-bold text-gray-900 dark:text-slate-100">Minhas turmas</h2>
         <Badge>{turmas.length} turma{turmas.length !== 1 ? 's' : ''}</Badge>
       </div>
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
@@ -53,14 +53,14 @@ export function ListaMinhasTurmas({ turmas }: ListaMinhasTurmasProps) {
                   <Shield className="w-5 h-5 text-brand-primary" />
                 </div>
                 <div className="space-y-1 min-w-0">
-                  <h3 className="text-lg font-semibold text-gray-900 truncate">
+                  <h3 className="text-lg font-semibold text-gray-900 dark:text-slate-100 truncate">
                     {turma.nome}
                   </h3>
-                  <p className="text-sm text-gray-500 truncate">{turma.disciplina}</p>
+                  <p className="text-sm text-gray-500 dark:text-slate-400 truncate">{turma.disciplina}</p>
                 </div>
               </div>
-              <div className="flex items-center gap-2 text-sm text-gray-600">
-                <Users className="w-4 h-4 text-gray-400 shrink-0" />
+              <div className="flex items-center gap-2 text-sm text-gray-600 dark:text-slate-300">
+                <Users className="w-4 h-4 text-gray-400 dark:text-slate-500 shrink-0" />
                 <span className="truncate">
                   {coordenador ?? 'Coordenador'}
                 </span>

--- a/clarify-next/src/app/(dashboard)/centraldemandas/page.tsx
+++ b/clarify-next/src/app/(dashboard)/centraldemandas/page.tsx
@@ -123,7 +123,7 @@ export default function CentralDemandasPage() {
 
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
             <CardMetrica titulo="Total" valor={total} label="solicitações">
-              <FileText className="w-4 h-4 text-gray-400 mb-1.5" />
+              <FileText className="w-4 h-4 text-gray-400 dark:text-slate-500 mb-1.5" />
             </CardMetrica>
             <CardMetrica titulo="Pendentes" valor={pendentes} label="aguardando análise">
               <Clock className="w-4 h-4 text-yellow-500 mb-1.5" />
@@ -141,7 +141,7 @@ export default function CentralDemandasPage() {
           {recentes.length > 0 && (
             <section>
               <div className="flex items-center justify-between mb-3">
-                <h2 className="text-lg font-bold text-gray-900">Demandas Recentes</h2>
+                <h2 className="text-lg font-bold text-gray-900 dark:text-slate-100">Demandas Recentes</h2>
                 <button
                   type="button"
                   onClick={() => router.push('/centraldemandas?view=demandas')}
@@ -191,7 +191,7 @@ export default function CentralDemandasPage() {
               </svg>
             </CardMetrica>
             <CardMetrica titulo="Eficiência" valor={`${eficiencia}%`} label="Demandas concluídas sobre o total">
-              <div className="flex-1 h-2 bg-gray-100 rounded-full overflow-hidden">
+              <div className="flex-1 h-2 bg-gray-100 dark:bg-slate-700 rounded-full overflow-hidden">
                 <div className="h-full bg-brand-primary rounded-full" style={{ width: `${eficiencia}%` }} />
               </div>
             </CardMetrica>
@@ -234,12 +234,12 @@ export default function CentralDemandasPage() {
 
           {concluidas.length > 0 && (
             <section>
-              <h2 className="text-lg font-bold text-gray-900 mb-3">Histórico</h2>
+              <h2 className="text-lg font-bold text-gray-900 dark:text-slate-100 mb-3">Histórico</h2>
 
-              <div className="hidden md:block bg-white rounded-xl border border-gray-200 overflow-x-auto">
+              <div className="hidden md:block bg-white dark:bg-slate-800 rounded-xl border border-gray-200 dark:border-slate-700 overflow-x-auto">
                 <table className="w-full text-left border-collapse">
                   <thead>
-                    <tr className="text-[10px] font-bold text-gray-400 uppercase tracking-widest">
+                    <tr className="text-[10px] font-bold text-gray-400 dark:text-slate-500 uppercase tracking-widest">
                       <th className="pb-2 pt-3 px-4">Protocolo</th>
                       <th className="pb-2 pt-3 px-4">Assunto</th>
                       <th className="pb-2 pt-3 px-4">Status</th>

--- a/clarify-next/src/app/(dashboard)/dashboardcoord/_components/DemandaCard.tsx
+++ b/clarify-next/src/app/(dashboard)/dashboardcoord/_components/DemandaCard.tsx
@@ -11,7 +11,7 @@ interface DemandaCardProps {
 
 export function DemandaCard({ demanda: d, onVerDetalhes, onAprovar, onReprovar }: DemandaCardProps) {
   return (
-    <div className="bg-white border border-gray-200 rounded-2xl p-5 shadow-lg hover:-translate-y-1 transition-transform duration-200 ease-out flex flex-col justify-between h-full">
+    <div className="bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 rounded-2xl p-5 shadow-lg hover:-translate-y-1 transition-transform duration-200 ease-out flex flex-col justify-between h-full">
       <button
         type="button"
         onClick={() => onVerDetalhes(d.protocolo)}
@@ -19,19 +19,19 @@ export function DemandaCard({ demanda: d, onVerDetalhes, onAprovar, onReprovar }
       >
         <div className="flex items-start justify-between gap-4 mb-4">
           <div className="min-w-0 space-y-2">
-            <h3 className="text-lg font-semibold text-gray-900 truncate">{d.tipo}</h3>
-            <p className="text-sm text-gray-500 line-clamp-2">{d.descricao}</p>
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-slate-100 truncate">{d.tipo}</h3>
+            <p className="text-sm text-gray-500 dark:text-slate-400 line-clamp-2">{d.descricao}</p>
           </div>
           <span className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold shrink-0 ${
-            d.status === 'pendente' ? 'bg-yellow-100 text-yellow-800' :
-            d.status === 'em_analise' ? 'bg-blue-100 text-blue-800' :
-            'bg-orange-100 text-orange-800'
+            d.status === 'pendente' ? 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/40 dark:text-yellow-200' :
+            d.status === 'em_analise' ? 'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-200' :
+            'bg-orange-100 text-orange-800 dark:bg-orange-900/40 dark:text-orange-200'
           }`}>
             {d.status.replace('_', ' ').toUpperCase()}
           </span>
         </div>
-        <div className="grid gap-1 text-sm text-gray-500">
-          <p><span className="font-semibold text-gray-800">Protocolo:</span> {d.protocolo}</p>
+        <div className="grid gap-1 text-sm text-gray-500 dark:text-slate-400">
+          <p><span className="font-semibold text-gray-800 dark:text-slate-200">Protocolo:</span> {d.protocolo}</p>
         </div>
       </button>
       <div className="mt-4 flex items-center gap-2">
@@ -45,7 +45,7 @@ export function DemandaCard({ demanda: d, onVerDetalhes, onAprovar, onReprovar }
         <button
           type="button"
           onClick={() => onReprovar(d.protocolo)}
-          className="flex-1 bg-gray-900 text-white py-2 px-3 rounded-lg text-xs font-semibold hover:bg-gray-800 transition-colors cursor-pointer border-none"
+          className="flex-1 bg-gray-900 dark:bg-slate-700 text-white py-2 px-3 rounded-lg text-xs font-semibold hover:bg-gray-800 dark:hover:bg-slate-600 transition-colors cursor-pointer border-none"
         >
           Reprovar
         </button>

--- a/clarify-next/src/app/(dashboard)/dashboardcoord/_components/ListaAlunos.tsx
+++ b/clarify-next/src/app/(dashboard)/dashboardcoord/_components/ListaAlunos.tsx
@@ -12,9 +12,9 @@ interface ListaAlunosProps {
 export function ListaAlunos({ alunos, demandas, onRemover }: ListaAlunosProps) {
   return (
     <section>
-      <h2 className="text-xl font-bold text-gray-900 mb-4">Alunos</h2>
+      <h2 className="text-xl font-bold text-gray-900 dark:text-slate-100 mb-4">Alunos</h2>
       {alunos.length === 0 ? (
-        <div className="text-center py-12 text-gray-400">
+        <div className="text-center py-12 text-gray-400 dark:text-slate-400">
           <p className="text-sm">Nenhum aluno cadastrado.</p>
         </div>
       ) : (

--- a/clarify-next/src/app/(dashboard)/dashboardcoord/_components/ListaChaves.tsx
+++ b/clarify-next/src/app/(dashboard)/dashboardcoord/_components/ListaChaves.tsx
@@ -47,7 +47,7 @@ export function ListaChaves({
   return (
     <section>
       <div className="flex items-center justify-between mb-4">
-        <h2 className="text-xl font-bold text-gray-900">Chaves de Ativação</h2>
+        <h2 className="text-xl font-bold text-gray-900 dark:text-slate-100">Chaves de Ativação</h2>
         <button
           type="button"
           onClick={onGerar}
@@ -64,15 +64,15 @@ export function ListaChaves({
       </div>
 
       {ultimaGerada && (
-        <div className="mb-4 p-4 bg-green-50 border border-green-200 rounded-xl flex items-center gap-3">
-          <span className="text-green-700 text-sm font-medium">
+        <div className="mb-4 p-4 bg-green-50 dark:bg-green-900/30 border border-green-200 dark:border-green-800 rounded-xl flex items-center gap-3">
+          <span className="text-green-700 dark:text-green-300 text-sm font-medium">
             Chave gerada:{' '}
             <strong className="font-mono text-base">{ultimaGerada.code}</strong>
           </span>
           <button
             type="button"
             onClick={() => copiarChave(ultimaGerada.code, ultimaGerada.id)}
-            className="ml-auto text-green-600 hover:text-green-800 transition-colors"
+            className="ml-auto text-green-600 dark:text-green-400 hover:text-green-800 dark:hover:text-green-300 transition-colors"
           >
             {copiedId === ultimaGerada.id ? (
               <Check className="w-4 h-4" />
@@ -88,46 +88,46 @@ export function ListaChaves({
           <span className="inline-block w-8 h-8 border-2 border-orange-600/30 border-t-orange-600 rounded-full animate-spin" />
         </div>
       ) : chaves.length === 0 ? (
-        <div className="flex flex-col items-center justify-center py-16 text-gray-500 gap-3">
-          <KeyRound className="w-12 h-12 text-gray-300" />
+        <div className="flex flex-col items-center justify-center py-16 text-gray-500 dark:text-slate-400 gap-3">
+          <KeyRound className="w-12 h-12 text-gray-300 dark:text-slate-600" />
           <p className="text-lg font-medium">Nenhuma chave cadastrada</p>
           <p className="text-sm">Gere a primeira chave de ativação para começar.</p>
         </div>
       ) : (
-        <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
+        <div className="bg-white dark:bg-slate-800 rounded-xl border border-gray-200 dark:border-slate-700 overflow-hidden">
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
               <thead>
-                <tr className="border-b border-gray-100 bg-gray-50">
-                  <th className="text-left px-5 py-3 font-semibold text-gray-600">Chave</th>
-                  <th className="text-left px-5 py-3 font-semibold text-gray-600">Status</th>
-                  <th className="text-left px-5 py-3 font-semibold text-gray-600 hidden sm:table-cell">
+                <tr className="border-b border-gray-100 dark:border-slate-700 bg-gray-50 dark:bg-slate-900">
+                  <th className="text-left px-5 py-3 font-semibold text-gray-600 dark:text-slate-300">Chave</th>
+                  <th className="text-left px-5 py-3 font-semibold text-gray-600 dark:text-slate-300">Status</th>
+                  <th className="text-left px-5 py-3 font-semibold text-gray-600 dark:text-slate-300 hidden sm:table-cell">
                     Criada em
                   </th>
-                  <th className="text-left px-5 py-3 font-semibold text-gray-600 w-20">Ações</th>
+                  <th className="text-left px-5 py-3 font-semibold text-gray-600 dark:text-slate-300 w-20">Ações</th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-gray-50">
+              <tbody className="divide-y divide-gray-50 dark:divide-slate-700">
                 {chaves.map((chave) => (
-                  <tr key={chave.id} className="hover:bg-orange-50/30 transition-colors">
-                    <td className="px-5 py-3 font-mono text-gray-700">{chave.code}</td>
+                  <tr key={chave.id} className="hover:bg-orange-50/30 dark:hover:bg-slate-700/50 transition-colors">
+                    <td className="px-5 py-3 font-mono text-gray-700 dark:text-slate-300">{chave.code}</td>
                     <td className="px-5 py-3">
                       <Badge variant={chave.used ? 'default' : 'concluido'}>
                         {chave.used ? 'Usada' : 'Disponível'}
                       </Badge>
                     </td>
-                    <td className="px-5 py-3 text-gray-500 hidden sm:table-cell">
+                    <td className="px-5 py-3 text-gray-500 dark:text-slate-400 hidden sm:table-cell">
                       {formatarData(chave.created_at)}
                     </td>
                     <td className="px-5 py-3">
                       <button
                         type="button"
                         onClick={() => copiarChave(chave.code, chave.id)}
-                        className="p-2 rounded-lg hover:bg-gray-100 transition-colors text-gray-500 hover:text-orange-600"
+                        className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-slate-700 transition-colors text-gray-500 dark:text-slate-400 hover:text-orange-600"
                         title="Copiar chave"
                       >
                         {copiedId === chave.id ? (
-                          <Check className="w-4 h-4 text-green-600" />
+                          <Check className="w-4 h-4 text-green-600 dark:text-green-400" />
                         ) : (
                           <Copy className="w-4 h-4" />
                         )}

--- a/clarify-next/src/app/(dashboard)/dashboardcoord/_components/ListaDemandas.tsx
+++ b/clarify-next/src/app/(dashboard)/dashboardcoord/_components/ListaDemandas.tsx
@@ -13,9 +13,9 @@ interface ListaDemandasProps {
 export function ListaDemandas({ demandas, onVerDetalhes, onAprovar, onReprovar }: ListaDemandasProps) {
   return (
     <section>
-      <h2 className="text-xl font-bold text-gray-900 mb-4">Demandas</h2>
+      <h2 className="text-xl font-bold text-gray-900 dark:text-slate-100 mb-4">Demandas</h2>
       {demandas.length === 0 ? (
-        <div className="text-center py-12 text-gray-400">
+        <div className="text-center py-12 text-gray-400 dark:text-slate-400">
           <p className="text-sm">Nenhuma demanda pendente.</p>
         </div>
       ) : (

--- a/clarify-next/src/app/(dashboard)/dashboardcoord/_components/ListaTurmas.tsx
+++ b/clarify-next/src/app/(dashboard)/dashboardcoord/_components/ListaTurmas.tsx
@@ -116,7 +116,7 @@ export function ListaTurmas({ turmas, loading, onCriarTurma, onEditarTurma, onEx
   return (
     <section>
       <div className="flex items-center justify-between mb-4">
-        <h2 className="text-xl font-bold text-gray-900">Turmas</h2>
+        <h2 className="text-xl font-bold text-gray-900 dark:text-slate-100">Turmas</h2>
         <button
           type="button"
           onClick={onCriarTurma}
@@ -143,14 +143,14 @@ export function ListaTurmas({ turmas, loading, onCriarTurma, onEditarTurma, onEx
 
       {/* Result count */}
       {!loading && (
-        <p className="text-sm text-gray-500 mb-3">
+        <p className="text-sm text-gray-500 dark:text-slate-400 mb-3">
           {filtradas.length} turma{filtradas.length !== 1 ? 's' : ''} encontrada{filtradas.length !== 1 ? 's' : ''}
         </p>
       )}
 
       {/* Loading state */}
       {loading && (
-        <div className="flex flex-col items-center justify-center py-16 text-gray-400">
+        <div className="flex flex-col items-center justify-center py-16 text-gray-400 dark:text-slate-400">
           <Loader2 className="w-8 h-8 animate-spin mb-3" />
           <p className="text-sm">Carregando turmas...</p>
         </div>
@@ -158,16 +158,16 @@ export function ListaTurmas({ turmas, loading, onCriarTurma, onEditarTurma, onEx
 
       {/* Empty state */}
       {!loading && filtradas.length === 0 && (
-        <div className="flex flex-col items-center justify-center py-16 text-gray-400">
+        <div className="flex flex-col items-center justify-center py-16 text-gray-400 dark:text-slate-400">
           <AlertCircle className="w-10 h-10 mb-3" />
           {turmas.length === 0 ? (
             <>
-              <p className="text-sm font-medium text-gray-500 mb-1">Nenhuma turma criada ainda.</p>
+              <p className="text-sm font-medium text-gray-500 dark:text-slate-400 mb-1">Nenhuma turma criada ainda.</p>
               <p className="text-xs">Crie sua primeira turma para começar.</p>
             </>
           ) : (
             <>
-              <p className="text-sm font-medium text-gray-500 mb-1">Nenhuma turma encontrada</p>
+              <p className="text-sm font-medium text-gray-500 dark:text-slate-400 mb-1">Nenhuma turma encontrada</p>
               <p className="text-xs">Tente remover alguns filtros para ver mais resultados.</p>
               <button
                 type="button"
@@ -200,8 +200,8 @@ export function ListaTurmas({ turmas, loading, onCriarTurma, onEditarTurma, onEx
                 className={cn(
                   "inline-flex items-center gap-1 px-3 py-1.5 text-sm rounded-lg transition-colors border cursor-pointer",
                   paginaSegura <= 1
-                    ? "border-gray-100 text-gray-300 cursor-not-allowed"
-                    : "border-gray-200 text-gray-600 hover:border-brand-primary hover:text-brand-primary"
+                    ? "border-gray-100 dark:border-slate-700 text-gray-300 dark:text-slate-600 cursor-not-allowed"
+                    : "border-gray-200 dark:border-slate-700 text-gray-600 dark:text-slate-300 hover:border-brand-primary hover:text-brand-primary"
                 )}
                 aria-label="Página anterior"
               >
@@ -219,7 +219,7 @@ export function ListaTurmas({ turmas, loading, onCriarTurma, onEditarTurma, onEx
                       "w-8 h-8 text-sm rounded-lg transition-colors cursor-pointer border",
                       p === paginaSegura
                         ? "bg-brand-primary text-white border-brand-primary font-semibold"
-                        : "border-gray-200 text-gray-600 hover:border-brand-primary hover:text-brand-primary"
+                        : "border-gray-200 dark:border-slate-700 text-gray-600 dark:text-slate-300 hover:border-brand-primary hover:text-brand-primary"
                     )}
                     aria-label={`Página ${p}`}
                     aria-current={p === paginaSegura ? 'page' : undefined}
@@ -236,8 +236,8 @@ export function ListaTurmas({ turmas, loading, onCriarTurma, onEditarTurma, onEx
                 className={cn(
                   "inline-flex items-center gap-1 px-3 py-1.5 text-sm rounded-lg transition-colors border cursor-pointer",
                   paginaSegura >= totalPaginas
-                    ? "border-gray-100 text-gray-300 cursor-not-allowed"
-                    : "border-gray-200 text-gray-600 hover:border-brand-primary hover:text-brand-primary"
+                    ? "border-gray-100 dark:border-slate-700 text-gray-300 dark:text-slate-600 cursor-not-allowed"
+                    : "border-gray-200 dark:border-slate-700 text-gray-600 dark:text-slate-300 hover:border-brand-primary hover:text-brand-primary"
                 )}
                 aria-label="Próxima página"
               >

--- a/clarify-next/src/app/(dashboard)/dashboardcoord/_components/VisaoGeral.tsx
+++ b/clarify-next/src/app/(dashboard)/dashboardcoord/_components/VisaoGeral.tsx
@@ -45,7 +45,7 @@ export function VisaoGeral({
         <CardMetrica titulo="Alunos Vinculados" valor={totalAlunos} label="total de alunos" />
         <CardMetrica titulo="Demandas Abertas" valor={demandasAbertas} label="aguardando ação" />
         <CardMetrica titulo="Resolução" valor={`${resolvidas}%`} label="demandas concluídas">
-          <div className="flex-1 h-2 bg-gray-100 rounded-full overflow-hidden">
+          <div className="flex-1 h-2 bg-gray-100 dark:bg-slate-700 rounded-full overflow-hidden">
             <div className="h-full bg-brand-primary rounded-full" style={{ width: `${resolvidas}%` }} />
           </div>
         </CardMetrica>
@@ -53,7 +53,7 @@ export function VisaoGeral({
 
       {demandasPendentes.length > 0 && (
         <section>
-          <h2 className="text-lg font-bold text-gray-900 mb-3">Demandas Pendentes</h2>
+          <h2 className="text-lg font-bold text-gray-900 dark:text-slate-100 mb-3">Demandas Pendentes</h2>
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
             {demandasPendentes.slice(0, 6).map((d) => (
               <DemandaCard

--- a/clarify-next/src/app/(dashboard)/layout.tsx
+++ b/clarify-next/src/app/(dashboard)/layout.tsx
@@ -37,7 +37,7 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
   };
 
   return (
-    <div className="flex h-screen overflow-hidden bg-white">
+    <div className="flex h-screen overflow-hidden bg-[var(--background)] text-[var(--foreground)]">
       <Suspense fallback={<div className="hidden md:block w-64 bg-gray-50 border-r border-gray-200" />}>
         <SidebarNav
           cargo={usuario.cargo}

--- a/clarify-next/src/app/(dashboard)/layout.tsx
+++ b/clarify-next/src/app/(dashboard)/layout.tsx
@@ -38,7 +38,7 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
 
   return (
     <div className="flex h-screen overflow-hidden bg-[var(--background)] text-[var(--foreground)]">
-      <Suspense fallback={<div className="hidden md:block w-64 bg-gray-50 border-r border-gray-200" />}>
+      <Suspense fallback={<div className="hidden md:block w-64 bg-gray-50 dark:bg-slate-900 border-r border-gray-200 dark:border-slate-700" />}>
         <SidebarNav
           cargo={usuario.cargo}
           drawerOpen={drawerOpen}

--- a/clarify-next/src/app/(dashboard)/perfil/page.tsx
+++ b/clarify-next/src/app/(dashboard)/perfil/page.tsx
@@ -17,8 +17,8 @@ import {
 } from '@/schemas/perfil'
 import type { Cargo } from '@/types'
 
-const labelClass = "text-[0.6875rem] font-bold tracking-[0.18em] uppercase text-[rgba(15,23,42,0.45)]"
-const inputClass = "w-full bg-transparent border-0 border-b-[1.5px] border-[rgba(15,23,42,0.10)] py-2 px-0 text-lg leading-[1.3] -tracking-[0.01em] text-[#0f172a] placeholder:text-[rgba(15,23,42,0.30)] placeholder:font-normal focus:outline-none focus:border-b-[#ca5f15] transition-[border-color] duration-180"
+const labelClass = "text-[0.6875rem] font-bold tracking-[0.18em] uppercase text-[rgba(15,23,42,0.45)] dark:text-slate-400"
+const inputClass = "w-full bg-transparent border-0 border-b-[1.5px] border-[rgba(15,23,42,0.10)] dark:border-slate-700 py-2 px-0 text-lg leading-[1.3] -tracking-[0.01em] text-[#0f172a] dark:text-slate-100 placeholder:text-[rgba(15,23,42,0.30)] dark:placeholder:text-slate-500 placeholder:font-normal focus:outline-none focus:border-b-[#ca5f15] transition-[border-color] duration-180"
 const dotClass = "inline-block w-1.5 h-1.5 rounded-full bg-[#ca5f15] shadow-[0_0_0_3px_rgba(202,95,21,0.18)]"
 const btnPrimaryClass = "inline-flex items-center gap-2 bg-[#ca5f15] text-white font-bold text-sm -tracking-[0.005em] py-3 px-5 rounded-xl shadow-[inset_0_1px_0_rgba(255,255,255,0.18),_0_1px_2px_rgba(202,95,21,0.30),_0_10px_24px_-10px_rgba(202,95,21,0.55)] hover:bg-[#b35211] hover:-translate-y-px active:translate-y-0 disabled:bg-[rgba(15,23,42,0.10)] disabled:text-[rgba(15,23,42,0.35)] disabled:shadow-none disabled:cursor-not-allowed disabled:transform-none transition-[transform,box-shadow,background-color] duration-180 cursor-pointer"
 
@@ -33,8 +33,8 @@ function Feedback({ msg }: { msg: Mensagem }) {
       className={cn(
         'inline-flex items-start gap-2 text-xs font-semibold rounded-lg px-3 py-2 border',
         msg.ok
-          ? 'text-green-700 bg-green-50 border-green-200'
-          : 'text-rose-700 bg-rose-50 border-rose-200'
+          ? 'text-green-700 bg-green-50 border-green-200 dark:text-green-300 dark:bg-green-900/30 dark:border-green-800'
+          : 'text-rose-700 bg-rose-50 border-rose-200 dark:text-rose-300 dark:bg-rose-900/30 dark:border-rose-800'
       )}
     >
       {!msg.ok && <AlertCircle className="w-4 h-4 mt-px shrink-0" />}
@@ -47,7 +47,7 @@ function Info({ label, value }: { label: string; value?: string }) {
   return (
     <div>
       <dt className={labelClass}>{label}</dt>
-      <dd className="text-base font-semibold text-gray-900 mt-1 break-words">{value || '—'}</dd>
+      <dd className="text-base font-semibold text-gray-900 dark:text-slate-100 mt-1 break-words">{value || '—'}</dd>
     </div>
   )
 }
@@ -107,8 +107,8 @@ export default function PerfilPage() {
       `}</style>
       <div className="p-4 sm:p-6 max-w-3xl mx-auto space-y-6">
         <header className="space-y-1">
-          <h1 className="text-2xl sm:text-3xl font-bold text-gray-900 tracking-tighter-2">Meu Perfil</h1>
-          <p className="text-sm text-gray-500">Gerencie suas informações pessoais e segurança.</p>
+          <h1 className="text-2xl sm:text-3xl font-bold text-gray-900 dark:text-slate-100 tracking-tighter-2">Meu Perfil</h1>
+          <p className="text-sm text-gray-500 dark:text-slate-400">Gerencie suas informações pessoais e segurança.</p>
         </header>
 
         <Card className="p-6 space-y-5">
@@ -141,7 +141,7 @@ export default function PerfilPage() {
                 placeholder="Seu nome completo"
               />
               {dadosForm.formState.errors.nome && (
-                <p className="text-xs text-red-600 mt-1">{dadosForm.formState.errors.nome.message}</p>
+                <p className="text-xs text-red-600 dark:text-red-400 mt-1">{dadosForm.formState.errors.nome.message}</p>
               )}
             </div>
 
@@ -155,7 +155,7 @@ export default function PerfilPage() {
                 placeholder="(00) 00000-0000"
               />
               {dadosForm.formState.errors.telefone && (
-                <p className="text-xs text-red-600 mt-1">{dadosForm.formState.errors.telefone.message}</p>
+                <p className="text-xs text-red-600 dark:text-red-400 mt-1">{dadosForm.formState.errors.telefone.message}</p>
               )}
             </div>
 
@@ -190,13 +190,13 @@ export default function PerfilPage() {
                   type="button"
                   onClick={() => setMostrarSenha(!mostrarSenha)}
                   tabIndex={-1}
-                  className="absolute right-0 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 transition-colors"
+                  className="absolute right-0 top-1/2 -translate-y-1/2 text-gray-400 dark:text-slate-500 hover:text-gray-600 dark:hover:text-slate-300 transition-colors"
                 >
                   {mostrarSenha ? <EyeOff size={20} /> : <Eye size={20} />}
                 </button>
               </div>
               {senhaForm.formState.errors.senha && (
-                <p className="text-xs text-red-600 mt-1">{senhaForm.formState.errors.senha.message}</p>
+                <p className="text-xs text-red-600 dark:text-red-400 mt-1">{senhaForm.formState.errors.senha.message}</p>
               )}
             </div>
 
@@ -214,13 +214,13 @@ export default function PerfilPage() {
                   type="button"
                   onClick={() => setMostrarConfirma(!mostrarConfirma)}
                   tabIndex={-1}
-                  className="absolute right-0 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 transition-colors"
+                  className="absolute right-0 top-1/2 -translate-y-1/2 text-gray-400 dark:text-slate-500 hover:text-gray-600 dark:hover:text-slate-300 transition-colors"
                 >
                   {mostrarConfirma ? <EyeOff size={20} /> : <Eye size={20} />}
                 </button>
               </div>
               {senhaForm.formState.errors.confirmacao && (
-                <p className="text-xs text-red-600 mt-1">{senhaForm.formState.errors.confirmacao.message}</p>
+                <p className="text-xs text-red-600 dark:text-red-400 mt-1">{senhaForm.formState.errors.confirmacao.message}</p>
               )}
             </div>
 

--- a/clarify-next/src/app/globals.css
+++ b/clarify-next/src/app/globals.css
@@ -1,5 +1,25 @@
 @import "tailwindcss";
 
+/* Dark mode por classe .dark no <html> (Tailwind v4 não lê darkMode do config sem @config) */
+@custom-variant dark (&:where(.dark, .dark *));
+
+:root {
+  --background: #ffffff;
+  --surface: #ffffff;
+  --foreground: #0f172a;
+  --brand: #ca5f15;
+  --border: #e5e7eb;
+}
+
+.dark {
+  --background: #0f172a;
+  --surface: #1e293b;
+  --foreground: #f8fafc;
+  --brand: #e07a30;
+  --border: #334155;
+  color-scheme: dark;
+}
+
 html {
   scroll-behavior: smooth;
 }

--- a/clarify-next/src/app/layout.tsx
+++ b/clarify-next/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Space_Grotesk } from "next/font/google";
 import { AuthProvider } from "@/context/AuthContext";
+import { ThemeProvider } from "@/context/ThemeContext";
 import { QueryProvider } from "@/components/providers/QueryProvider";
 import "./globals.css";
 
@@ -23,11 +24,13 @@ export default function RootLayout({
   return (
     <html lang="pt-br" className={`${spaceGrotesk.variable} h-full antialiased`}>
       <body className="min-h-full bg-brand-surface font-sans">
-        <QueryProvider>
-          <AuthProvider>
-            {children}
-          </AuthProvider>
-        </QueryProvider>
+        <ThemeProvider>
+          <QueryProvider>
+            <AuthProvider>
+              {children}
+            </AuthProvider>
+          </QueryProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/clarify-next/src/app/login/page.tsx
+++ b/clarify-next/src/app/login/page.tsx
@@ -57,7 +57,7 @@ export default function LoginPage() {
           display: none !important;
         }
       `}</style>
-    <div className="min-h-screen w-full flex items-center justify-center p-4 relative overflow-hidden bg-brand-surface">
+    <div className="min-h-screen w-full flex items-center justify-center p-4 relative overflow-hidden bg-brand-surface dark:bg-slate-900">
       {/* Fundo Geométrico com Losangos */}
       <div
         className="absolute inset-0 opacity-15 pointer-events-none animate-cubes"
@@ -75,22 +75,22 @@ export default function LoginPage() {
         }}
       />
 
-      <div className="w-full max-w-md bg-white rounded-2xl shadow-xl p-8 z-10 border border-brand-surface-dim">
+      <div className="w-full max-w-md bg-white dark:bg-slate-800 rounded-2xl shadow-xl p-8 z-10 border border-brand-surface-dim dark:border-slate-700">
         <div className="flex flex-col items-center mb-8">
           <div className="w-20 h-20 mb-4 bg-orange-50 rounded-xl p-2 flex items-center justify-center">
             <Image src="/GATOGORDO.png" alt="Clarify Logo" width={72} height={72} className="w-full h-full object-contain" />
           </div>
-          <h1 className="text-3xl font-bold text-gray-900">Clarify</h1>
-          <p className="text-sm font-medium text-gray-500 tracking-wider uppercase mt-1">Acesso - Instituto Federal</p>
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-slate-100">Clarify</h1>
+          <p className="text-sm font-medium text-gray-500 dark:text-slate-400 tracking-wider uppercase mt-1">Acesso - Instituto Federal</p>
         </div>
 
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
           <div>
-            <label htmlFor="login-matricula" className="block text-xs font-bold text-gray-700 uppercase tracking-widest mb-2 ml-1">
+            <label htmlFor="login-matricula" className="block text-xs font-bold text-gray-700 dark:text-slate-300 uppercase tracking-widest mb-2 ml-1">
               ID Institucional
             </label>
             <div className="relative">
-              <span className="absolute inset-y-0 left-0 pl-3 flex items-center text-gray-400">
+              <span className="absolute inset-y-0 left-0 pl-3 flex items-center text-gray-400 dark:text-slate-400">
                 <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path
                     strokeLinecap="round"
@@ -105,17 +105,17 @@ export default function LoginPage() {
                 type="text"
                 {...register('matricula')}
                 placeholder="e.g. 123456789"
-                className="block w-full pl-10 pr-3 py-3 border border-gray-200 rounded-lg bg-gray-50 text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-brand-primary focus:border-transparent transition-all"
+                className="block w-full pl-10 pr-3 py-3 border border-gray-200 dark:border-slate-700 rounded-lg bg-gray-50 dark:bg-slate-800 text-gray-900 dark:text-slate-100 placeholder-gray-400 dark:placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-brand-primary focus:border-transparent transition-all"
                 disabled={isLoading}
               />
             </div>
             {errors.matricula && (
-              <p className="text-xs text-red-600 mt-1 ml-1">{errors.matricula.message}</p>
+              <p className="text-xs text-red-600 dark:text-red-400 mt-1 ml-1">{errors.matricula.message}</p>
             )}
           </div>
 
           <div>
-            <label htmlFor="login-senha" className="block text-xs font-bold text-gray-700 uppercase tracking-widest mb-2 ml-1">
+            <label htmlFor="login-senha" className="block text-xs font-bold text-gray-700 dark:text-slate-300 uppercase tracking-widest mb-2 ml-1">
               Chave de Segurança
             </label>
             <div className="relative">
@@ -124,26 +124,26 @@ export default function LoginPage() {
                 type={mostrarSenha ? 'text' : 'password'}
                 {...register('senha')}
                 placeholder="••••••••"
-                className="block w-full pl-3 pr-10 py-3 border border-gray-200 rounded-lg bg-gray-50 text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-brand-primary focus:border-transparent transition-all"
+                className="block w-full pl-3 pr-10 py-3 border border-gray-200 dark:border-slate-700 rounded-lg bg-gray-50 dark:bg-slate-800 text-gray-900 dark:text-slate-100 placeholder-gray-400 dark:placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-brand-primary focus:border-transparent transition-all"
                 disabled={isLoading}
               />
               <button
                 type="button"
                 onClick={() => setMostrarSenha(!mostrarSenha)}
                 tabIndex={-1}
-                className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 transition-colors"
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 dark:text-slate-400 hover:text-gray-600 dark:hover:text-slate-200 transition-colors"
               >
                 {mostrarSenha ? <EyeOff size={20} /> : <Eye size={20} />}
               </button>
             </div>
             {errors.senha && (
-              <p className="text-xs text-red-600 mt-1 ml-1">{errors.senha.message}</p>
+              <p className="text-xs text-red-600 dark:text-red-400 mt-1 ml-1">{errors.senha.message}</p>
             )}
           </div>
 
           {error && (
-            <div className="p-3 bg-red-50 border border-red-200 rounded-lg">
-              <p className="text-xs font-bold text-red-700 uppercase tracking-widest">{error}</p>
+            <div className="p-3 bg-red-50 dark:bg-red-950/40 border border-red-200 dark:border-red-900 rounded-lg">
+              <p className="text-xs font-bold text-red-700 dark:text-red-300 uppercase tracking-widest">{error}</p>
             </div>
           )}
 
@@ -166,8 +166,8 @@ export default function LoginPage() {
         </form>
 
         <div className="mt-12 text-center">
-          <p className="text-xs text-gray-400 font-medium">Somente indivíduos autorizados.</p>
-          <p className="text-xs text-gray-300 mt-1">Versão v0.0.0</p>
+          <p className="text-xs text-gray-400 dark:text-slate-400 font-medium">Somente indivíduos autorizados.</p>
+          <p className="text-xs text-gray-300 dark:text-slate-500 mt-1">Versão v0.0.0</p>
         </div>
       </div>
     </div>

--- a/clarify-next/src/app/not-found.tsx
+++ b/clarify-next/src/app/not-found.tsx
@@ -7,14 +7,14 @@ export default function NotFound() {
   const router = useRouter()
 
   return (
-    <div className="min-h-screen w-full flex items-center justify-center p-4 bg-brand-surface">
+    <div className="min-h-screen w-full flex items-center justify-center p-4 bg-brand-surface dark:bg-slate-900">
       <div className="text-center max-w-md">
         <div className="mb-8">
           <h1 className="text-8xl md:text-9xl font-bold text-brand-primary">404</h1>
-          <p className="text-xl md:text-2xl font-bold text-slate-900 mt-4">Página não encontrada</p>
+          <p className="text-xl md:text-2xl font-bold text-slate-900 dark:text-slate-100 mt-4">Página não encontrada</p>
         </div>
 
-        <p className="text-slate-600 text-base mb-8">
+        <p className="text-slate-600 dark:text-slate-300 text-base mb-8">
           A página que você está procurando não existe ou foi movida. Retorne à página inicial e tente novamente.
         </p>
 
@@ -29,7 +29,7 @@ export default function NotFound() {
           <button
             type="button"
             onClick={() => router.back()}
-            className="inline-flex items-center justify-center w-full px-6 py-3 border border-slate-200 text-slate-900 font-semibold rounded-xl hover:bg-slate-50 transition-colors"
+            className="inline-flex items-center justify-center w-full px-6 py-3 border border-slate-200 dark:border-slate-700 text-slate-900 dark:text-slate-100 font-semibold rounded-xl hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors"
           >
             Voltar
           </button>

--- a/clarify-next/src/app/page.tsx
+++ b/clarify-next/src/app/page.tsx
@@ -37,7 +37,7 @@ export default function LandingPage() {
   }, [])
 
   return (
-    <div className="relative min-h-screen text-slate-900 overflow-x-hidden bg-brand-surface">
+    <div className="relative min-h-screen text-slate-900 dark:text-slate-100 overflow-x-hidden bg-brand-surface dark:bg-slate-900">
       {/* Fundo sutil */}
       <div className="pointer-events-none fixed inset-0 -z-10">
         <div className="absolute inset-0 opacity-25"></div>
@@ -47,7 +47,7 @@ export default function LandingPage() {
       {/* Navbar */}
       <nav
         className={`sticky top-0 z-30 border-b transition-all duration-300 ${
-          scrolled ? 'border-slate-200/50 bg-white/80 backdrop-blur' : 'border-transparent'
+          scrolled ? 'border-slate-200/50 dark:border-slate-700/50 bg-white/80 dark:bg-slate-900/80 backdrop-blur' : 'border-transparent'
         }`}
       >
         <div className="max-w-6xl mx-auto px-6 h-16 flex items-center justify-between">
@@ -60,22 +60,22 @@ export default function LandingPage() {
               className="w-9 h-9 object-contain drop-shadow-[0_4px_12px_rgba(202,95,21,0.25)]"
             />
             <div className="leading-none">
-              <p className="text-base font-bold text-slate-900 tracking-tight">Clarify</p>
+              <p className="text-base font-bold text-slate-900 dark:text-slate-100 tracking-tight">Clarify</p>
               <p className="text-[9px] font-semibold uppercase tracking-[0.18em] text-slate-400 mt-0.5">Federal Institution</p>
             </div>
           </Link>
 
           <div className="hidden md:flex items-center gap-1">
-            <a href="#como-funciona" className="px-3 py-2 text-sm font-medium text-slate-600 hover:text-slate-900 transition-colors">
+            <a href="#como-funciona" className="px-3 py-2 text-sm font-medium text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-slate-100 transition-colors">
               Como funciona
             </a>
-            <a href="#quem-usa" className="px-3 py-2 text-sm font-medium text-slate-600 hover:text-slate-900 transition-colors">
+            <a href="#quem-usa" className="px-3 py-2 text-sm font-medium text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-slate-100 transition-colors">
               Perfis
             </a>
           </div>
 
           <div className="flex items-center gap-2">
-            <Link href="/registro" className="hidden sm:inline-flex items-center text-sm font-medium text-slate-500 hover:text-slate-900 px-3 py-2 transition-colors">
+            <Link href="/registro" className="hidden sm:inline-flex items-center text-sm font-medium text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-100 px-3 py-2 transition-colors">
               Criar conta
             </Link>
             <Link href="/login" className="inline-flex items-center gap-1.5 text-sm font-bold rounded-full px-4 py-2 bg-brand-primary text-white hover:bg-orange-700 transition-colors">
@@ -90,13 +90,13 @@ export default function LandingPage() {
       <section id="topo" className="relative pt-14 md:pt-24 pb-16 md:pb-24">
         <div className="max-w-6xl mx-auto px-6">
           <div className="text-center max-w-3xl mx-auto" data-reveal>
-            <h1 className="text-4xl md:text-6xl font-bold tracking-tight leading-[1.05] text-slate-900">
+            <h1 className="text-4xl md:text-6xl font-bold tracking-tight leading-[1.05] text-slate-900 dark:text-slate-100">
               Aberto, em análise,
               <br />
               <span className="text-gradient-warm">resolvido.</span>
             </h1>
 
-            <p className="mt-6 text-base md:text-lg text-slate-600 leading-relaxed">
+            <p className="mt-6 text-base md:text-lg text-slate-600 dark:text-slate-300 leading-relaxed">
               O caminho de cada solicitação acadêmica, do clique do aluno à resposta da coordenação. Em um lugar só, com protocolo único e histórico do semestre.
             </p>
 
@@ -105,7 +105,7 @@ export default function LandingPage() {
                 Entrar
                 <ArrowRight className="w-4 h-4" />
               </Link>
-              <Link href="/registro" className="inline-flex items-center justify-center gap-2 text-sm font-semibold rounded-xl px-6 py-3 bg-white border border-slate-200 text-slate-900 hover:bg-slate-50 transition-colors w-full sm:w-auto">
+              <Link href="/registro" className="inline-flex items-center justify-center gap-2 text-sm font-semibold rounded-xl px-6 py-3 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 text-slate-900 dark:text-slate-100 hover:bg-slate-50 dark:hover:bg-slate-700 transition-colors w-full sm:w-auto">
                 Criar conta
               </Link>
             </div>
@@ -121,13 +121,13 @@ export default function LandingPage() {
               <div className="absolute inset-x-10 top-6 h-72 rounded-[3rem] bg-gradient-to-br from-brand-primary/25 via-orange-300/25 to-amber-200/20 blur-3xl"></div>
             </div>
 
-            <div className="relative bg-white border border-slate-200/80 rounded-3xl shadow-2xl overflow-hidden">
-              <div className="flex items-center gap-2 px-5 py-3 border-b border-slate-100 bg-gradient-to-b from-slate-50 to-white">
+            <div className="relative bg-white dark:bg-slate-800 border border-slate-200/80 dark:border-slate-700 rounded-3xl shadow-2xl overflow-hidden">
+              <div className="flex items-center gap-2 px-5 py-3 border-b border-slate-100 dark:border-slate-700 bg-gradient-to-b from-slate-50 to-white dark:from-slate-900 dark:to-slate-800">
                 <span className="w-2.5 h-2.5 rounded-full bg-rose-300"></span>
                 <span className="w-2.5 h-2.5 rounded-full bg-amber-300"></span>
                 <span className="w-2.5 h-2.5 rounded-full bg-emerald-300"></span>
                 <span className="ml-3 text-[11px] text-slate-400 font-mono tracking-tight">clarify.app/centraldemandas</span>
-                <span className="ml-auto inline-flex items-center gap-1 text-[10px] font-bold text-emerald-600 bg-emerald-50 border border-emerald-100 rounded-full px-2 py-0.5">
+                <span className="ml-auto inline-flex items-center gap-1 text-[10px] font-bold text-emerald-600 dark:text-emerald-300 bg-emerald-50 dark:bg-emerald-950/40 border border-emerald-100 dark:border-emerald-900 rounded-full px-2 py-0.5">
                   <span className="w-1.5 h-1.5 rounded-full bg-emerald-500"></span>
                   ao vivo
                 </span>
@@ -137,7 +137,7 @@ export default function LandingPage() {
                 <div className="flex items-end justify-between mb-5">
                   <div>
                     <p className="text-[10px] font-bold text-slate-400 uppercase tracking-[0.22em]">Portal · Central de Demandas</p>
-                    <h3 className="text-xl md:text-2xl font-bold text-slate-900 mt-1">
+                    <h3 className="text-xl md:text-2xl font-bold text-slate-900 dark:text-slate-100 mt-1">
                       Em Aberto <span className="text-slate-300 ml-1 text-base">3</span>
                     </h3>
                   </div>
@@ -149,14 +149,14 @@ export default function LandingPage() {
 
                 <div className="grid md:grid-cols-3 gap-3.5">
                   {/* Card 1 */}
-                  <div className="bg-white rounded-xl border border-slate-200 p-4 flex flex-col gap-2.5">
+                  <div className="bg-white dark:bg-slate-900 rounded-xl border border-slate-200 dark:border-slate-700 p-4 flex flex-col gap-2.5">
                     <div className="flex items-center justify-between gap-2">
                       <span className="text-[10px] font-bold text-slate-400 tracking-[0.18em]">#REQ-402</span>
-                      <span className="text-[9px] font-bold uppercase tracking-[0.16em] px-2 py-0.5 rounded-full border bg-blue-50 text-blue-800 border-blue-200">Em Análise</span>
+                      <span className="text-[9px] font-bold uppercase tracking-[0.16em] px-2 py-0.5 rounded-full border bg-blue-50 text-blue-800 border-blue-200 dark:bg-blue-950/40 dark:text-blue-300 dark:border-blue-900">Em Análise</span>
                     </div>
-                    <h4 className="text-sm font-bold text-slate-900 leading-snug">Quebra de Pré-requisito</h4>
-                    <p className="text-[12px] text-slate-500 leading-relaxed line-clamp-2">Solicitação de matrícula em Compiladores antes de Linguagens Formais.</p>
-                    <div className="flex items-center gap-3 pt-2 border-t border-slate-100 text-[10px] text-slate-400">
+                    <h4 className="text-sm font-bold text-slate-900 dark:text-slate-100 leading-snug">Quebra de Pré-requisito</h4>
+                    <p className="text-[12px] text-slate-500 dark:text-slate-400 leading-relaxed line-clamp-2">Solicitação de matrícula em Compiladores antes de Linguagens Formais.</p>
+                    <div className="flex items-center gap-3 pt-2 border-t border-slate-100 dark:border-slate-700 text-[10px] text-slate-400">
                       <span className="inline-flex items-center gap-1">
                         <Calendar className="w-3 h-3" /> 02 Out
                       </span>
@@ -167,14 +167,14 @@ export default function LandingPage() {
                   </div>
 
                   {/* Card 2 */}
-                  <div className="bg-white rounded-xl border border-slate-200 p-4 flex flex-col gap-2.5">
+                  <div className="bg-white dark:bg-slate-900 rounded-xl border border-slate-200 dark:border-slate-700 p-4 flex flex-col gap-2.5">
                     <div className="flex items-center justify-between gap-2">
                       <span className="text-[10px] font-bold text-slate-400 tracking-[0.18em]">#REQ-419</span>
-                      <span className="text-[9px] font-bold uppercase tracking-[0.16em] px-2 py-0.5 rounded-full border bg-amber-50 text-amber-800 border-amber-200">Pendente</span>
+                      <span className="text-[9px] font-bold uppercase tracking-[0.16em] px-2 py-0.5 rounded-full border bg-amber-50 text-amber-800 border-amber-200 dark:bg-amber-950/40 dark:text-amber-300 dark:border-amber-900">Pendente</span>
                     </div>
-                    <h4 className="text-sm font-bold text-slate-900 leading-snug">Revisão de Prova</h4>
-                    <p className="text-[12px] text-slate-500 leading-relaxed line-clamp-2">Pedido de revisão da prova final de Estrutura de Dados.</p>
-                    <div className="flex items-center gap-3 pt-2 border-t border-slate-100 text-[10px] text-slate-400">
+                    <h4 className="text-sm font-bold text-slate-900 dark:text-slate-100 leading-snug">Revisão de Prova</h4>
+                    <p className="text-[12px] text-slate-500 dark:text-slate-400 leading-relaxed line-clamp-2">Pedido de revisão da prova final de Estrutura de Dados.</p>
+                    <div className="flex items-center gap-3 pt-2 border-t border-slate-100 dark:border-slate-700 text-[10px] text-slate-400">
                       <span className="inline-flex items-center gap-1">
                         <Calendar className="w-3 h-3" /> 02 Out
                       </span>
@@ -185,14 +185,14 @@ export default function LandingPage() {
                   </div>
 
                   {/* Card 3 */}
-                  <div className="bg-white rounded-xl border border-slate-200 p-4 flex flex-col gap-2.5">
+                  <div className="bg-white dark:bg-slate-900 rounded-xl border border-slate-200 dark:border-slate-700 p-4 flex flex-col gap-2.5">
                     <div className="flex items-center justify-between gap-2">
                       <span className="text-[10px] font-bold text-slate-400 tracking-[0.18em]">#REQ-443</span>
-                      <span className="text-[9px] font-bold uppercase tracking-[0.16em] px-2 py-0.5 rounded-full border bg-emerald-50 text-emerald-800 border-emerald-200">Concluído</span>
+                      <span className="text-[9px] font-bold uppercase tracking-[0.16em] px-2 py-0.5 rounded-full border bg-emerald-50 text-emerald-800 border-emerald-200 dark:bg-emerald-950/40 dark:text-emerald-300 dark:border-emerald-900">Concluído</span>
                     </div>
-                    <h4 className="text-sm font-bold text-slate-900 leading-snug">Cancelamento de Matrícula</h4>
-                    <p className="text-[12px] text-slate-500 leading-relaxed line-clamp-2">Solicitação de cancelamento em Linguagens Formais.</p>
-                    <div className="flex items-center gap-3 pt-2 border-t border-slate-100 text-[10px] text-slate-400">
+                    <h4 className="text-sm font-bold text-slate-900 dark:text-slate-100 leading-snug">Cancelamento de Matrícula</h4>
+                    <p className="text-[12px] text-slate-500 dark:text-slate-400 leading-relaxed line-clamp-2">Solicitação de cancelamento em Linguagens Formais.</p>
+                    <div className="flex items-center gap-3 pt-2 border-t border-slate-100 dark:border-slate-700 text-[10px] text-slate-400">
                       <span className="inline-flex items-center gap-1">
                         <Calendar className="w-3 h-3" /> 01 Out
                       </span>
@@ -212,8 +212,8 @@ export default function LandingPage() {
       <section id="como-funciona" className="relative py-16 md:py-24">
         <div className="max-w-6xl mx-auto px-6">
           <div className="text-center mb-12" data-reveal>
-            <h2 className="text-3xl md:text-5xl font-bold text-slate-900">Como funciona</h2>
-            <p className="mt-4 text-lg text-slate-600">Três passos para gerenciar todas as solicitações</p>
+            <h2 className="text-3xl md:text-5xl font-bold text-slate-900 dark:text-slate-100">Como funciona</h2>
+            <p className="mt-4 text-lg text-slate-600 dark:text-slate-300">Três passos para gerenciar todas as solicitações</p>
           </div>
 
           <div className="grid md:grid-cols-3 gap-8" data-reveal>
@@ -226,8 +226,8 @@ export default function LandingPage() {
                 <div className="w-16 h-16 rounded-full bg-brand-primary/10 flex items-center justify-center mb-4">
                   <item.icon className="w-8 h-8 text-brand-primary" />
                 </div>
-                <h3 className="text-lg font-bold text-slate-900">{item.title}</h3>
-                <p className="text-slate-600 mt-2">{item.desc}</p>
+                <h3 className="text-lg font-bold text-slate-900 dark:text-slate-100">{item.title}</h3>
+                <p className="text-slate-600 dark:text-slate-300 mt-2">{item.desc}</p>
               </div>
             ))}
           </div>
@@ -235,11 +235,11 @@ export default function LandingPage() {
       </section>
 
       {/* Perfis */}
-      <section id="quem-usa" className="relative py-16 md:py-24 bg-white/50">
+      <section id="quem-usa" className="relative py-16 md:py-24 bg-white/50 dark:bg-slate-800/50">
         <div className="max-w-6xl mx-auto px-6">
           <div className="text-center mb-12" data-reveal>
-            <h2 className="text-3xl md:text-5xl font-bold text-slate-900">Para alunos e coordenadores</h2>
-            <p className="mt-4 text-lg text-slate-600">Ferramentas pensadas para cada perfil</p>
+            <h2 className="text-3xl md:text-5xl font-bold text-slate-900 dark:text-slate-100">Para alunos e coordenadores</h2>
+            <p className="mt-4 text-lg text-slate-600 dark:text-slate-300">Ferramentas pensadas para cada perfil</p>
           </div>
 
           <div className="grid md:grid-cols-2 gap-8" data-reveal>
@@ -260,14 +260,14 @@ export default function LandingPage() {
                 icon: Eye,
               },
             ].map((profile) => (
-              <div key={profile.title} className="bg-white border border-slate-200 rounded-2xl p-8">
+              <div key={profile.title} className="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-2xl p-8">
                 <div className="flex items-center gap-3 mb-6">
                   <profile.icon className="w-8 h-8 text-brand-primary" />
-                  <h3 className="text-2xl font-bold text-slate-900">{profile.title}</h3>
+                  <h3 className="text-2xl font-bold text-slate-900 dark:text-slate-100">{profile.title}</h3>
                 </div>
                 <ul className="space-y-3">
                   {profile.features.map((feature) => (
-                    <li key={feature} className="flex items-center gap-3 text-slate-700">
+                    <li key={feature} className="flex items-center gap-3 text-slate-700 dark:text-slate-300">
                       <Check className="w-5 h-5 text-emerald-500" />
                       {feature}
                     </li>
@@ -282,14 +282,14 @@ export default function LandingPage() {
       {/* CTA Final */}
       <section className="relative py-16 md:py-24">
         <div className="max-w-3xl mx-auto px-6 text-center" data-reveal>
-          <h2 className="text-3xl md:text-5xl font-bold text-slate-900">Pronto para começar?</h2>
-          <p className="mt-4 text-lg text-slate-600">Entre com suas credenciais ou crie uma nova conta</p>
+          <h2 className="text-3xl md:text-5xl font-bold text-slate-900 dark:text-slate-100">Pronto para começar?</h2>
+          <p className="mt-4 text-lg text-slate-600 dark:text-slate-300">Entre com suas credenciais ou crie uma nova conta</p>
           <div className="mt-9 flex flex-col sm:flex-row items-center justify-center gap-3">
             <Link href="/login" className="inline-flex items-center justify-center gap-2 text-sm font-bold rounded-xl px-6 py-3 bg-brand-primary text-white hover:bg-orange-700 transition-colors w-full sm:w-auto">
               Entrar
               <ArrowRight className="w-4 h-4" />
             </Link>
-            <Link href="/registro" className="inline-flex items-center justify-center gap-2 text-sm font-semibold rounded-xl px-6 py-3 bg-white border border-slate-200 text-slate-900 hover:bg-slate-50 transition-colors w-full sm:w-auto">
+            <Link href="/registro" className="inline-flex items-center justify-center gap-2 text-sm font-semibold rounded-xl px-6 py-3 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 text-slate-900 dark:text-slate-100 hover:bg-slate-50 dark:hover:bg-slate-700 transition-colors w-full sm:w-auto">
               Criar conta
             </Link>
           </div>
@@ -297,9 +297,9 @@ export default function LandingPage() {
       </section>
 
       {/* Footer */}
-      <footer className="border-t border-slate-200 py-8 md:py-12 bg-slate-50">
+      <footer className="border-t border-slate-200 dark:border-slate-700 py-8 md:py-12 bg-slate-50 dark:bg-slate-900">
         <div className="max-w-6xl mx-auto px-6">
-          <div className="text-center text-slate-600 text-sm">
+          <div className="text-center text-slate-600 dark:text-slate-300 text-sm">
             <p>© 2026 Clarify. Todos os direitos reservados.</p>
             <p className="mt-2">Versão v0.0.0 · Federal Institution</p>
           </div>

--- a/clarify-next/src/app/registro/page.tsx
+++ b/clarify-next/src/app/registro/page.tsx
@@ -63,7 +63,7 @@ export default function RegistroPage() {
           display: none !important;
         }
       `}</style>
-    <div className="min-h-screen w-full flex items-center justify-center p-4 relative overflow-hidden bg-brand-surface">
+    <div className="min-h-screen w-full flex items-center justify-center p-4 relative overflow-hidden bg-brand-surface dark:bg-slate-900">
       {/* Fundo Geométrico com Losangos */}
       <div
         className="absolute inset-0 opacity-15 pointer-events-none animate-cubes"
@@ -81,22 +81,22 @@ export default function RegistroPage() {
         }}
       />
 
-      <div className="w-full max-w-md bg-white rounded-2xl shadow-xl p-8 z-10 border border-brand-surface-dim">
+      <div className="w-full max-w-md bg-white dark:bg-slate-800 rounded-2xl shadow-xl p-8 z-10 border border-brand-surface-dim dark:border-slate-700">
         <div className="flex flex-col items-center mb-8">
           <div className="w-20 h-20 mb-4 bg-orange-50 rounded-xl p-2 flex items-center justify-center">
             <Image src="/GATOGORDO.png" alt="Clarify Logo" width={72} height={72} className="w-full h-full object-contain" />
           </div>
-          <h1 className="text-3xl font-bold text-gray-900">Clarify</h1>
-          <p className="text-sm font-medium text-gray-500 tracking-wider uppercase mt-1">Acesso - Instituto Federal</p>
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-slate-100">Clarify</h1>
+          <p className="text-sm font-medium text-gray-500 dark:text-slate-400 tracking-wider uppercase mt-1">Acesso - Instituto Federal</p>
         </div>
 
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-5">
           <div>
-            <label htmlFor="registro-fullName" className="block text-xs font-bold text-gray-700 uppercase tracking-widest mb-2 ml-1">
+            <label htmlFor="registro-fullName" className="block text-xs font-bold text-gray-700 dark:text-slate-300 uppercase tracking-widest mb-2 ml-1">
               Nome Completo
             </label>
             <div className="relative">
-              <span className="absolute inset-y-0 left-0 pl-3 flex items-center text-gray-400">
+              <span className="absolute inset-y-0 left-0 pl-3 flex items-center text-gray-400 dark:text-slate-400">
                 <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path
                     strokeLinecap="round"
@@ -111,21 +111,21 @@ export default function RegistroPage() {
                 type="text"
                 {...register('nome')}
                 placeholder="e.g. John Doe"
-                className="block w-full pl-10 pr-3 py-3 border border-gray-200 rounded-lg bg-gray-50 text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-brand-primary focus:border-transparent transition-all"
+                className="block w-full pl-10 pr-3 py-3 border border-gray-200 dark:border-slate-700 rounded-lg bg-gray-50 dark:bg-slate-800 text-gray-900 dark:text-slate-100 placeholder-gray-400 dark:placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-brand-primary focus:border-transparent transition-all"
                 disabled={isLoading}
               />
             </div>
             {errors.nome && (
-              <p className="text-xs text-red-600 mt-1 ml-1">{errors.nome.message}</p>
+              <p className="text-xs text-red-600 dark:text-red-400 mt-1 ml-1">{errors.nome.message}</p>
             )}
           </div>
 
           <div>
-            <label htmlFor="registro-institutionalId" className="block text-xs font-bold text-gray-700 uppercase tracking-widest mb-2 ml-1">
+            <label htmlFor="registro-institutionalId" className="block text-xs font-bold text-gray-700 dark:text-slate-300 uppercase tracking-widest mb-2 ml-1">
               ID Institucional
             </label>
             <div className="relative">
-              <span className="absolute inset-y-0 left-0 pl-3 flex items-center text-gray-400">
+              <span className="absolute inset-y-0 left-0 pl-3 flex items-center text-gray-400 dark:text-slate-400">
                 <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path
                     strokeLinecap="round"
@@ -140,21 +140,21 @@ export default function RegistroPage() {
                 type="text"
                 {...register('matricula')}
                 placeholder="e.g. 123456789"
-                className="block w-full pl-10 pr-3 py-3 border border-gray-200 rounded-lg bg-gray-50 text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-brand-primary focus:border-transparent transition-all"
+                className="block w-full pl-10 pr-3 py-3 border border-gray-200 dark:border-slate-700 rounded-lg bg-gray-50 dark:bg-slate-800 text-gray-900 dark:text-slate-100 placeholder-gray-400 dark:placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-brand-primary focus:border-transparent transition-all"
                 disabled={isLoading}
               />
             </div>
             {errors.matricula && (
-              <p className="text-xs text-red-600 mt-1 ml-1">{errors.matricula.message}</p>
+              <p className="text-xs text-red-600 dark:text-red-400 mt-1 ml-1">{errors.matricula.message}</p>
             )}
           </div>
 
           <div>
-            <label htmlFor="registro-institutionalEmail" className="block text-xs font-bold text-gray-700 uppercase tracking-widest mb-2 ml-1">
+            <label htmlFor="registro-institutionalEmail" className="block text-xs font-bold text-gray-700 dark:text-slate-300 uppercase tracking-widest mb-2 ml-1">
               Email Institucional
             </label>
             <div className="relative">
-              <span className="absolute inset-y-0 left-0 pl-3 flex items-center text-gray-400">
+              <span className="absolute inset-y-0 left-0 pl-3 flex items-center text-gray-400 dark:text-slate-400">
                 <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path
                     strokeLinecap="round"
@@ -169,17 +169,17 @@ export default function RegistroPage() {
                 type="email"
                 {...register('email')}
                 placeholder="e.g. john.doe@academico.edu.br"
-                className="block w-full pl-10 pr-3 py-3 border border-gray-200 rounded-lg bg-gray-50 text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-brand-primary focus:border-transparent transition-all"
+                className="block w-full pl-10 pr-3 py-3 border border-gray-200 dark:border-slate-700 rounded-lg bg-gray-50 dark:bg-slate-800 text-gray-900 dark:text-slate-100 placeholder-gray-400 dark:placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-brand-primary focus:border-transparent transition-all"
                 disabled={isLoading}
               />
             </div>
             {errors.email && (
-              <p className="text-xs text-red-600 mt-1 ml-1">{errors.email.message}</p>
+              <p className="text-xs text-red-600 dark:text-red-400 mt-1 ml-1">{errors.email.message}</p>
             )}
           </div>
 
           <div>
-            <label htmlFor="registro-securityKey" className="block text-xs font-bold text-gray-700 uppercase tracking-widest mb-2 ml-1">
+            <label htmlFor="registro-securityKey" className="block text-xs font-bold text-gray-700 dark:text-slate-300 uppercase tracking-widest mb-2 ml-1">
               Chave de Segurança
             </label>
             <div className="relative">
@@ -188,29 +188,29 @@ export default function RegistroPage() {
                 type={mostrarSenha ? 'text' : 'password'}
                 {...register('senha')}
                 placeholder="••••••••"
-                className="block w-full pl-3 pr-10 py-3 border border-gray-200 rounded-lg bg-gray-50 text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-brand-primary focus:border-transparent transition-all"
+                className="block w-full pl-3 pr-10 py-3 border border-gray-200 dark:border-slate-700 rounded-lg bg-gray-50 dark:bg-slate-800 text-gray-900 dark:text-slate-100 placeholder-gray-400 dark:placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-brand-primary focus:border-transparent transition-all"
                 disabled={isLoading}
               />
               <button
                 type="button"
                 onClick={() => setMostrarSenha(!mostrarSenha)}
                 tabIndex={-1}
-                className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 transition-colors"
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 dark:text-slate-400 hover:text-gray-600 dark:hover:text-slate-200 transition-colors"
               >
                 {mostrarSenha ? <EyeOff size={20} /> : <Eye size={20} />}
               </button>
             </div>
             {errors.senha && (
-              <p className="text-xs text-red-600 mt-1 ml-1">{errors.senha.message}</p>
+              <p className="text-xs text-red-600 dark:text-red-400 mt-1 ml-1">{errors.senha.message}</p>
             )}
           </div>
 
           <div>
-            <label htmlFor="registro-activationKey" className="block text-xs font-bold text-gray-700 uppercase tracking-widest mb-2 ml-1">
+            <label htmlFor="registro-activationKey" className="block text-xs font-bold text-gray-700 dark:text-slate-300 uppercase tracking-widest mb-2 ml-1">
               Chave de Ativação
             </label>
             <div className="relative">
-              <span className="absolute inset-y-0 left-0 pl-3 flex items-center text-gray-400">
+              <span className="absolute inset-y-0 left-0 pl-3 flex items-center text-gray-400 dark:text-slate-400">
                 <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path
                     strokeLinecap="round"
@@ -225,18 +225,18 @@ export default function RegistroPage() {
                 type="text"
                 {...register('chaveAtivacao')}
                 placeholder="Chave fornecida pela instituição"
-                className="block w-full pl-10 pr-3 py-3 border border-gray-200 rounded-lg bg-gray-50 text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-brand-primary focus:border-transparent transition-all"
+                className="block w-full pl-10 pr-3 py-3 border border-gray-200 dark:border-slate-700 rounded-lg bg-gray-50 dark:bg-slate-800 text-gray-900 dark:text-slate-100 placeholder-gray-400 dark:placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-brand-primary focus:border-transparent transition-all"
                 disabled={isLoading}
               />
             </div>
             {errors.chaveAtivacao && (
-              <p className="text-xs text-red-600 mt-1 ml-1">{errors.chaveAtivacao.message}</p>
+              <p className="text-xs text-red-600 dark:text-red-400 mt-1 ml-1">{errors.chaveAtivacao.message}</p>
             )}
           </div>
 
           {error && (
-            <div className="p-3 bg-red-50 border border-red-200 rounded-lg">
-              <p className="text-xs font-bold text-red-700 uppercase tracking-widest">{error}</p>
+            <div className="p-3 bg-red-50 dark:bg-red-950/40 border border-red-200 dark:border-red-900 rounded-lg">
+              <p className="text-xs font-bold text-red-700 dark:text-red-300 uppercase tracking-widest">{error}</p>
             </div>
           )}
 
@@ -256,8 +256,8 @@ export default function RegistroPage() {
         </form>
 
         <div className="mt-8 text-center">
-          <p className="text-xs text-gray-400 font-medium">Somente indivíduos autorizados.</p>
-          <p className="text-xs text-gray-300 mt-1">Versão v0.0.0</p>
+          <p className="text-xs text-gray-400 dark:text-slate-400 font-medium">Somente indivíduos autorizados.</p>
+          <p className="text-xs text-gray-300 dark:text-slate-500 mt-1">Versão v0.0.0</p>
         </div>
       </div>
     </div>

--- a/clarify-next/src/components/coordenador/CardAluno.tsx
+++ b/clarify-next/src/components/coordenador/CardAluno.tsx
@@ -18,24 +18,24 @@ export function CardAluno({ aluno, demandasEmAberto, onRemover }: CardAlunoProps
   return (
     <Card className="p-5 hover:-translate-y-1 transition-transform duration-200 ease-out">
       <div className="flex items-center gap-4 mb-4">
-        <div className="w-12 h-12 rounded-full bg-gray-100 flex items-center justify-center text-gray-700 font-bold text-sm shrink-0">
+        <div className="w-12 h-12 rounded-full bg-gray-100 dark:bg-slate-700 flex items-center justify-center text-gray-700 dark:text-slate-300 font-bold text-sm shrink-0">
           {iniciais}
         </div>
         <div className="min-w-0">
-          <h3 className="text-base font-semibold text-gray-900 truncate">{aluno.nome}</h3>
-          <p className="text-xs text-gray-400 truncate">{aluno.email}</p>
+          <h3 className="text-base font-semibold text-gray-900 dark:text-slate-100 truncate">{aluno.nome}</h3>
+          <p className="text-xs text-gray-400 dark:text-slate-400 truncate">{aluno.email}</p>
         </div>
       </div>
-      <div className="grid gap-2 text-sm text-gray-600">
+      <div className="grid gap-2 text-sm text-gray-600 dark:text-slate-300">
         <p className="truncate">
-          <span className="font-semibold text-gray-800">Nome:</span> {aluno.nome}
+          <span className="font-semibold text-gray-800 dark:text-slate-200">Nome:</span> {aluno.nome}
         </p>
         <p>
-          <span className="font-semibold text-gray-800">Matrícula:</span>
+          <span className="font-semibold text-gray-800 dark:text-slate-200">Matrícula:</span>
           <Badge variant="blue" className="ml-1">{aluno.matricula}</Badge>
         </p>
         <p>
-          <span className="font-semibold text-gray-800">Demandas em aberto:</span>
+          <span className="font-semibold text-gray-800 dark:text-slate-200">Demandas em aberto:</span>
           <Badge variant="blue" className="ml-1">{demandasEmAberto}</Badge>
         </p>
       </div>
@@ -44,7 +44,7 @@ export function CardAluno({ aluno, demandasEmAberto, onRemover }: CardAlunoProps
         <button
           type="button"
           onClick={() => onRemover(aluno.matricula)}
-          className="mt-4 inline-flex items-center justify-center rounded-lg border border-rose-200 px-3 py-2 text-xs font-semibold text-rose-700 hover:bg-rose-50 transition-colors cursor-pointer"
+          className="mt-4 inline-flex items-center justify-center rounded-lg border border-rose-200 dark:border-rose-900/50 px-3 py-2 text-xs font-semibold text-rose-700 dark:text-rose-300 hover:bg-rose-50 dark:hover:bg-rose-900/30 transition-colors cursor-pointer"
         >
           Remover aluno
         </button>

--- a/clarify-next/src/components/coordenador/CardMetrica.tsx
+++ b/clarify-next/src/components/coordenador/CardMetrica.tsx
@@ -11,14 +11,14 @@ interface CardMetricaProps {
 export function CardMetrica({ titulo, valor, children, label }: CardMetricaProps) {
   return (
     <Card className="p-5">
-      <p className="text-[10px] font-bold text-gray-400 uppercase tracking-widest">
+      <p className="text-[10px] font-bold text-gray-400 dark:text-slate-400 uppercase tracking-widest">
         {titulo}
       </p>
       <div className="flex items-end gap-3 mt-2">
-        <span className="text-3xl font-extrabold text-gray-900 leading-none">{valor}</span>
+        <span className="text-3xl font-extrabold text-gray-900 dark:text-slate-100 leading-none">{valor}</span>
         {children}
       </div>
-      {label && <p className="text-[10px] text-gray-400 mt-1">{label}</p>}
+      {label && <p className="text-[10px] text-gray-400 dark:text-slate-400 mt-1">{label}</p>}
     </Card>
   );
 }

--- a/clarify-next/src/components/coordenador/CardTurma.tsx
+++ b/clarify-next/src/components/coordenador/CardTurma.tsx
@@ -16,8 +16,8 @@ export function CardTurma({ turma, onEditar, onExcluir }: CardTurmaProps) {
     <Card className="p-5 hover:-translate-y-1 transition-transform duration-200 ease-out">
       <div className="flex items-start justify-between gap-4 mb-4">
         <div className="space-y-1">
-          <h3 className="text-lg font-semibold text-gray-900">{turma.nome}</h3>
-          <p className="text-sm text-gray-500">{turma.disciplina}</p>
+          <h3 className="text-lg font-semibold text-gray-900 dark:text-slate-100">{turma.nome}</h3>
+          <p className="text-sm text-gray-500 dark:text-slate-400">{turma.disciplina}</p>
         </div>
         <div className="flex items-center gap-2">
           <Badge variant="orange">
@@ -27,7 +27,7 @@ export function CardTurma({ turma, onEditar, onExcluir }: CardTurmaProps) {
             <button
               type="button"
               onClick={() => onEditar(turma)}
-              className="p-1.5 rounded-lg text-gray-400 hover:text-brand-primary hover:bg-brand-primary/10 transition-colors cursor-pointer"
+              className="p-1.5 rounded-lg text-gray-400 dark:text-slate-400 hover:text-brand-primary hover:bg-brand-primary/10 transition-colors cursor-pointer"
               title="Editar turma"
             >
               <Pencil className="w-4 h-4" />
@@ -37,7 +37,7 @@ export function CardTurma({ turma, onEditar, onExcluir }: CardTurmaProps) {
             <button
               type="button"
               onClick={() => onExcluir(turma.id)}
-              className="p-1.5 rounded-lg text-gray-400 hover:text-red-600 hover:bg-red-50 transition-colors cursor-pointer"
+              className="p-1.5 rounded-lg text-gray-400 dark:text-slate-400 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-900/30 transition-colors cursor-pointer"
               title="Excluir turma"
             >
               <Trash2 className="w-4 h-4" />
@@ -45,8 +45,8 @@ export function CardTurma({ turma, onEditar, onExcluir }: CardTurmaProps) {
           )}
         </div>
       </div>
-      <div className="text-sm text-gray-500">
-        <span className="font-semibold text-gray-700">ID:</span> {turma.id}
+      <div className="text-sm text-gray-500 dark:text-slate-400">
+        <span className="font-semibold text-gray-700 dark:text-slate-300">ID:</span> {turma.id}
       </div>
     </Card>
   );

--- a/clarify-next/src/components/coordenador/FiltroTurmas.tsx
+++ b/clarify-next/src/components/coordenador/FiltroTurmas.tsx
@@ -69,7 +69,7 @@ export function FiltroTurmas({
   const filtrosMobile = (
     <div className="space-y-4">
       <div className="relative">
-        <Search className="w-3.5 h-3.5 text-gray-400 absolute left-2.5 top-1/2 -translate-y-1/2 pointer-events-none" />
+        <Search className="w-3.5 h-3.5 text-gray-400 dark:text-slate-500 absolute left-2.5 top-1/2 -translate-y-1/2 pointer-events-none" />
         <input
           ref={buscaRef}
           type="text"
@@ -83,7 +83,7 @@ export function FiltroTurmas({
           <button
             type="button"
             onClick={() => { setBuscaLocal(''); onBuscaChange(''); }}
-            className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 cursor-pointer bg-transparent border-none"
+            className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 dark:text-slate-500 hover:text-gray-600 dark:hover:text-slate-300 cursor-pointer bg-transparent border-none"
             aria-label="Limpar busca"
           >
             <X className="w-3.5 h-3.5" />
@@ -92,10 +92,10 @@ export function FiltroTurmas({
       </div>
 
       <div>
-        <label className="block text-xs font-semibold text-gray-500 mb-1.5 uppercase tracking-wide">Disciplina</label>
+        <label className="block text-xs font-semibold text-gray-500 dark:text-slate-400 mb-1.5 uppercase tracking-wide">Disciplina</label>
         <div className="space-y-1.5 max-h-48 overflow-y-auto">
           {disciplinasDisponiveis.map((d) => (
-            <label key={d} className="flex items-center gap-2 text-sm text-gray-700 cursor-pointer hover:text-gray-900">
+            <label key={d} className="flex items-center gap-2 text-sm text-gray-700 dark:text-slate-300 cursor-pointer hover:text-gray-900 dark:hover:text-slate-100">
               <input
                 type="checkbox"
                 checked={disciplinas.includes(d)}
@@ -106,13 +106,13 @@ export function FiltroTurmas({
             </label>
           ))}
           {disciplinasDisponiveis.length === 0 && (
-            <p className="text-xs text-gray-400">Nenhuma disciplina disponível</p>
+            <p className="text-xs text-gray-400 dark:text-slate-400">Nenhuma disciplina disponível</p>
           )}
         </div>
       </div>
 
       <div>
-        <label className="block text-xs font-semibold text-gray-500 mb-1.5 uppercase tracking-wide">Qtd. de alunos</label>
+        <label className="block text-xs font-semibold text-gray-500 dark:text-slate-400 mb-1.5 uppercase tracking-wide">Qtd. de alunos</label>
         <div className="flex items-center gap-2">
           <input
             type="number"
@@ -121,9 +121,9 @@ export function FiltroTurmas({
             onChange={(e) => onMinAlunosChange(e.target.value)}
             placeholder="Mín"
             aria-label="Mínimo de alunos"
-            className="w-full px-3 py-2 border border-gray-200 rounded-lg bg-gray-50 text-sm outline-none focus:border-brand-primary focus:bg-white transition-colors [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+            className="w-full px-3 py-2 border border-gray-200 dark:border-slate-700 rounded-lg bg-gray-50 dark:bg-slate-900 text-sm dark:text-slate-100 dark:placeholder:text-slate-500 outline-none focus:border-brand-primary focus:bg-white dark:focus:bg-slate-800 transition-colors [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
           />
-          <span className="text-gray-400 text-sm">—</span>
+          <span className="text-gray-400 dark:text-slate-500 text-sm">—</span>
           <input
             type="number"
             min={0}
@@ -131,7 +131,7 @@ export function FiltroTurmas({
             onChange={(e) => onMaxAlunosChange(e.target.value)}
             placeholder="Máx"
             aria-label="Máximo de alunos"
-            className="w-full px-3 py-2 border border-gray-200 rounded-lg bg-gray-50 text-sm outline-none focus:border-brand-primary focus:bg-white transition-colors [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+            className="w-full px-3 py-2 border border-gray-200 dark:border-slate-700 rounded-lg bg-gray-50 dark:bg-slate-900 text-sm dark:text-slate-100 dark:placeholder:text-slate-500 outline-none focus:border-brand-primary focus:bg-white dark:focus:bg-slate-800 transition-colors [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
           />
         </div>
       </div>
@@ -151,23 +151,23 @@ export function FiltroTurmas({
   return (
     <>
       {/* Desktop filter bar */}
-      <div className="hidden sm:block bg-white rounded-xl border border-gray-200 p-3.5">
+      <div className="hidden sm:block bg-white dark:bg-slate-800 rounded-xl border border-gray-200 dark:border-slate-700 p-3.5">
         <div className="flex flex-wrap gap-2 items-center">
           <div className="flex-1 min-w-[180px] relative">
-            <Search className="w-3.5 h-3.5 text-gray-400 absolute left-2.5 top-1/2 -translate-y-1/2 pointer-events-none" />
+            <Search className="w-3.5 h-3.5 text-gray-400 dark:text-slate-500 absolute left-2.5 top-1/2 -translate-y-1/2 pointer-events-none" />
             <input
               type="text"
               value={buscaLocal}
               onChange={(e) => setBuscaLocal(e.target.value)}
               placeholder="Buscar turma..."
               aria-label="Buscar turma"
-              className="w-full pl-8 pr-8 py-2 border border-gray-200 rounded-lg bg-gray-50 text-sm outline-none focus:border-brand-primary focus:bg-white transition-colors"
+              className="w-full pl-8 pr-8 py-2 border border-gray-200 dark:border-slate-700 rounded-lg bg-gray-50 dark:bg-slate-900 text-sm dark:text-slate-100 dark:placeholder:text-slate-500 outline-none focus:border-brand-primary focus:bg-white dark:focus:bg-slate-800 transition-colors"
             />
             {buscaLocal && (
               <button
                 type="button"
                 onClick={() => { setBuscaLocal(''); onBuscaChange(''); }}
-                className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 cursor-pointer bg-transparent border-none"
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 dark:text-slate-500 hover:text-gray-600 dark:hover:text-slate-300 cursor-pointer bg-transparent border-none"
                 aria-label="Limpar busca"
               >
                 <X className="w-3.5 h-3.5" />
@@ -184,7 +184,7 @@ export function FiltroTurmas({
                 "inline-flex items-center gap-1.5 px-3 py-2 border rounded-lg text-sm outline-none transition-colors cursor-pointer whitespace-nowrap",
                 disciplinas.length > 0
                   ? "border-brand-primary bg-brand-primary/5 text-brand-primary font-semibold"
-                  : "border-gray-200 bg-gray-50 text-gray-600 hover:border-gray-300"
+                  : "border-gray-200 dark:border-slate-700 bg-gray-50 dark:bg-slate-900 text-gray-600 dark:text-slate-300 hover:border-gray-300 dark:hover:border-slate-600"
               )}
               aria-label="Filtrar por disciplina"
               aria-expanded={dropdownAberto}
@@ -196,15 +196,15 @@ export function FiltroTurmas({
                   {disciplinas.length}
                 </span>
               )}
-              <ChevronDown className="w-3 h-3 text-gray-400" />
+              <ChevronDown className="w-3 h-3 text-gray-400 dark:text-slate-500" />
             </button>
 
             {dropdownAberto && (
-              <div className="absolute top-full mt-1 right-0 z-20 w-56 bg-white rounded-xl border border-gray-200 shadow-lg p-3">
-                <p className="text-xs font-semibold text-gray-500 mb-2 uppercase tracking-wide">Disciplinas</p>
+              <div className="absolute top-full mt-1 right-0 z-20 w-56 bg-white dark:bg-slate-800 rounded-xl border border-gray-200 dark:border-slate-700 shadow-lg p-3">
+                <p className="text-xs font-semibold text-gray-500 dark:text-slate-400 mb-2 uppercase tracking-wide">Disciplinas</p>
                 <div className="space-y-1.5 max-h-48 overflow-y-auto">
                   {disciplinasDisponiveis.map((d) => (
-                    <label key={d} className="flex items-center gap-2 text-sm text-gray-700 cursor-pointer hover:text-gray-900 px-1 py-0.5 rounded">
+                    <label key={d} className="flex items-center gap-2 text-sm text-gray-700 dark:text-slate-300 cursor-pointer hover:text-gray-900 dark:hover:text-slate-100 px-1 py-0.5 rounded">
                       <input
                         type="checkbox"
                         checked={disciplinas.includes(d)}
@@ -215,7 +215,7 @@ export function FiltroTurmas({
                     </label>
                   ))}
                   {disciplinasDisponiveis.length === 0 && (
-                    <p className="text-xs text-gray-400 py-1">Nenhuma disciplina disponível</p>
+                    <p className="text-xs text-gray-400 dark:text-slate-400 py-1">Nenhuma disciplina disponível</p>
                   )}
                 </div>
               </div>
@@ -235,10 +235,10 @@ export function FiltroTurmas({
                 "w-24 px-3 py-2 border rounded-lg text-sm outline-none transition-colors [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none",
                 minAlunos !== ''
                   ? "border-brand-primary bg-brand-primary/5 text-brand-primary"
-                  : "border-gray-200 bg-gray-50 text-gray-600 focus:border-brand-primary focus:bg-white"
+                  : "border-gray-200 dark:border-slate-700 bg-gray-50 dark:bg-slate-900 text-gray-600 dark:text-slate-300 focus:border-brand-primary focus:bg-white dark:focus:bg-slate-800"
               )}
             />
-            <span className="text-gray-300 text-sm">—</span>
+            <span className="text-gray-300 dark:text-slate-600 text-sm">—</span>
             <input
               type="number"
               min={0}
@@ -250,7 +250,7 @@ export function FiltroTurmas({
                 "w-24 px-3 py-2 border rounded-lg text-sm outline-none transition-colors [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none",
                 maxAlunos !== ''
                   ? "border-brand-primary bg-brand-primary/5 text-brand-primary"
-                  : "border-gray-200 bg-gray-50 text-gray-600 focus:border-brand-primary focus:bg-white"
+                  : "border-gray-200 dark:border-slate-700 bg-gray-50 dark:bg-slate-900 text-gray-600 dark:text-slate-300 focus:border-brand-primary focus:bg-white dark:focus:bg-slate-800"
               )}
             />
           </div>
@@ -270,8 +270,8 @@ export function FiltroTurmas({
 
         {/* Active filter tags */}
         {temFiltroAtivo && (
-          <div className="flex flex-wrap items-center gap-1.5 mt-2.5 pt-2.5 border-t border-gray-100">
-            <span className="text-xs text-gray-400 font-medium mr-1">
+          <div className="flex flex-wrap items-center gap-1.5 mt-2.5 pt-2.5 border-t border-gray-100 dark:border-slate-700">
+            <span className="text-xs text-gray-400 dark:text-slate-400 font-medium mr-1">
               {qtdFiltros} filtro{qtdFiltros !== 1 ? 's' : ''} ativo{qtdFiltros !== 1 ? 's' : ''}:
             </span>
             {busca.trim() && (
@@ -288,12 +288,12 @@ export function FiltroTurmas({
               </span>
             )}
             {disciplinas.map((d) => (
-              <span key={d} className="inline-flex items-center gap-1 px-2 py-0.5 bg-blue-100 text-blue-700 text-xs font-medium rounded-full">
+              <span key={d} className="inline-flex items-center gap-1 px-2 py-0.5 bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-200 text-xs font-medium rounded-full">
                 {d}
                 <button
                   type="button"
                   onClick={() => toggleDisciplina(d)}
-                  className="text-blue-700 hover:text-blue-500 cursor-pointer bg-transparent border-none p-0"
+                  className="text-blue-700 dark:text-blue-300 hover:text-blue-500 dark:hover:text-blue-200 cursor-pointer bg-transparent border-none p-0"
                   aria-label={`Remover filtro ${d}`}
                 >
                   <X className="w-3 h-3" />
@@ -301,12 +301,12 @@ export function FiltroTurmas({
               </span>
             ))}
             {minAlunos !== '' && (
-              <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-green-100 text-green-700 text-xs font-medium rounded-full">
+              <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-200 text-xs font-medium rounded-full">
                 Mín: {minAlunos}
                 <button
                   type="button"
                   onClick={() => onMinAlunosChange('')}
-                  className="text-green-700 hover:text-green-500 cursor-pointer bg-transparent border-none p-0"
+                  className="text-green-700 dark:text-green-300 hover:text-green-500 dark:hover:text-green-200 cursor-pointer bg-transparent border-none p-0"
                   aria-label="Remover filtro mínimo"
                 >
                   <X className="w-3 h-3" />
@@ -314,12 +314,12 @@ export function FiltroTurmas({
               </span>
             )}
             {maxAlunos !== '' && (
-              <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-green-100 text-green-700 text-xs font-medium rounded-full">
+              <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-200 text-xs font-medium rounded-full">
                 Máx: {maxAlunos}
                 <button
                   type="button"
                   onClick={() => onMaxAlunosChange('')}
-                  className="text-green-700 hover:text-green-500 cursor-pointer bg-transparent border-none p-0"
+                  className="text-green-700 dark:text-green-300 hover:text-green-500 dark:hover:text-green-200 cursor-pointer bg-transparent border-none p-0"
                   aria-label="Remover filtro máximo"
                 >
                   <X className="w-3 h-3" />
@@ -334,14 +334,14 @@ export function FiltroTurmas({
       <div className="sm:hidden">
         <div className="flex items-center gap-2">
           <div className="flex-1 relative">
-            <Search className="w-3.5 h-3.5 text-gray-400 absolute left-2.5 top-1/2 -translate-y-1/2 pointer-events-none" />
+            <Search className="w-3.5 h-3.5 text-gray-400 dark:text-slate-500 absolute left-2.5 top-1/2 -translate-y-1/2 pointer-events-none" />
             <input
               type="text"
               value={buscaLocal}
               onChange={(e) => setBuscaLocal(e.target.value)}
               placeholder="Buscar turma..."
               aria-label="Buscar turma"
-              className="w-full pl-8 pr-3 py-2 border border-gray-200 rounded-lg bg-gray-50 text-sm outline-none focus:border-brand-primary focus:bg-white transition-colors"
+              className="w-full pl-8 pr-3 py-2 border border-gray-200 dark:border-slate-700 rounded-lg bg-gray-50 dark:bg-slate-900 text-sm dark:text-slate-100 dark:placeholder:text-slate-500 outline-none focus:border-brand-primary focus:bg-white dark:focus:bg-slate-800 transition-colors"
             />
           </div>
           <button
@@ -351,7 +351,7 @@ export function FiltroTurmas({
               "relative inline-flex items-center justify-center w-10 h-10 border rounded-lg transition-colors cursor-pointer",
               temFiltroAtivo
                 ? "border-brand-primary bg-brand-primary/5 text-brand-primary"
-                : "border-gray-200 bg-gray-50 text-gray-500 hover:border-gray-300"
+                : "border-gray-200 dark:border-slate-700 bg-gray-50 dark:bg-slate-900 text-gray-500 dark:text-slate-400 hover:border-gray-300 dark:hover:border-slate-600"
             )}
             aria-label="Abrir filtros"
           >
@@ -380,25 +380,25 @@ export function FiltroTurmas({
               </span>
             )}
             {disciplinas.map((d) => (
-              <span key={d} className="inline-flex items-center gap-1 px-2 py-0.5 bg-blue-100 text-blue-700 text-xs font-medium rounded-full">
+              <span key={d} className="inline-flex items-center gap-1 px-2 py-0.5 bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-200 text-xs font-medium rounded-full">
                 {d}
-                <button type="button" onClick={() => toggleDisciplina(d)} className="text-blue-700 hover:text-blue-500 cursor-pointer bg-transparent border-none p-0">
+                <button type="button" onClick={() => toggleDisciplina(d)} className="text-blue-700 dark:text-blue-300 hover:text-blue-500 dark:hover:text-blue-200 cursor-pointer bg-transparent border-none p-0">
                   <X className="w-3 h-3" />
                 </button>
               </span>
             ))}
             {minAlunos !== '' && (
-              <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-green-100 text-green-700 text-xs font-medium rounded-full">
+              <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-200 text-xs font-medium rounded-full">
                 Mín: {minAlunos}
-                <button type="button" onClick={() => onMinAlunosChange('')} className="text-green-700 hover:text-green-500 cursor-pointer bg-transparent border-none p-0">
+                <button type="button" onClick={() => onMinAlunosChange('')} className="text-green-700 dark:text-green-300 hover:text-green-500 dark:hover:text-green-200 cursor-pointer bg-transparent border-none p-0">
                   <X className="w-3 h-3" />
                 </button>
               </span>
             )}
             {maxAlunos !== '' && (
-              <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-green-100 text-green-700 text-xs font-medium rounded-full">
+              <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-200 text-xs font-medium rounded-full">
                 Máx: {maxAlunos}
-                <button type="button" onClick={() => onMaxAlunosChange('')} className="text-green-700 hover:text-green-500 cursor-pointer bg-transparent border-none p-0">
+                <button type="button" onClick={() => onMaxAlunosChange('')} className="text-green-700 dark:text-green-300 hover:text-green-500 dark:hover:text-green-200 cursor-pointer bg-transparent border-none p-0">
                   <X className="w-3 h-3" />
                 </button>
               </span>
@@ -413,13 +413,13 @@ export function FiltroTurmas({
               className="absolute inset-0 bg-[rgba(20,12,8,0.42)]"
               onClick={() => setMobileFiltrosAberto(false)}
             />
-            <div className="absolute bottom-0 left-0 right-0 bg-white rounded-t-3xl shadow-xl max-h-[80vh] overflow-y-auto">
-              <div className="flex items-center justify-between px-5 pt-4 pb-2 border-b border-gray-100">
-                <h3 className="text-base font-bold text-gray-900">Filtros</h3>
+            <div className="absolute bottom-0 left-0 right-0 bg-white dark:bg-slate-800 rounded-t-3xl shadow-xl max-h-[80vh] overflow-y-auto">
+              <div className="flex items-center justify-between px-5 pt-4 pb-2 border-b border-gray-100 dark:border-slate-700">
+                <h3 className="text-base font-bold text-gray-900 dark:text-slate-100">Filtros</h3>
                 <button
                   type="button"
                   onClick={() => setMobileFiltrosAberto(false)}
-                  className="text-gray-400 hover:text-gray-600 cursor-pointer bg-transparent border-none p-1"
+                  className="text-gray-400 dark:text-slate-500 hover:text-gray-600 dark:hover:text-slate-300 cursor-pointer bg-transparent border-none p-1"
                   aria-label="Fechar filtros"
                 >
                   <X className="w-5 h-5" />

--- a/clarify-next/src/components/coordenador/FormAdicionarAluno.tsx
+++ b/clarify-next/src/components/coordenador/FormAdicionarAluno.tsx
@@ -13,8 +13,8 @@ interface FormAdicionarAlunoProps {
   existe: (matricula: string, email: string) => Promise<boolean>;
 }
 
-const labelClass = "text-[0.6875rem] font-bold tracking-[0.18em] uppercase text-[rgba(15,23,42,0.45)]";
-const inputClass = "w-full bg-transparent border-0 border-b-[1.5px] border-[rgba(15,23,42,0.10)] py-2 px-0 text-lg leading-[1.3] -tracking-[0.01em] text-[#0f172a] placeholder:text-[rgba(15,23,42,0.30)] placeholder:font-normal focus:outline-none focus:border-b-[#ca5f15] transition-[border-color] duration-180";
+const labelClass = "text-[0.6875rem] font-bold tracking-[0.18em] uppercase text-[rgba(15,23,42,0.45)] dark:text-slate-400";
+const inputClass = "w-full bg-transparent border-0 border-b-[1.5px] border-[rgba(15,23,42,0.10)] dark:border-slate-700 py-2 px-0 text-lg leading-[1.3] -tracking-[0.01em] text-[#0f172a] dark:text-slate-100 placeholder:text-[rgba(15,23,42,0.30)] dark:placeholder:text-slate-500 placeholder:font-normal focus:outline-none focus:border-b-[#ca5f15] transition-[border-color] duration-180";
 const dotClass = "inline-block w-1.5 h-1.5 rounded-full bg-[#ca5f15] shadow-[0_0_0_3px_rgba(202,95,21,0.18)]";
 const btnPrimaryClass = "inline-flex items-center gap-2 bg-[#ca5f15] text-white font-bold text-sm -tracking-[0.005em] py-3 px-5 rounded-xl shadow-[inset_0_1px_0_rgba(255,255,255,0.18),_0_1px_2px_rgba(202,95,21,0.30),_0_10px_24px_-10px_rgba(202,95,21,0.55)] hover:bg-[#b35211] hover:-translate-y-px active:translate-y-0 disabled:bg-[rgba(15,23,42,0.10)] disabled:text-[rgba(15,23,42,0.35)] disabled:shadow-none disabled:cursor-not-allowed disabled:transform-none transition-[transform,box-shadow,background-color] duration-180 cursor-pointer";
 
@@ -68,23 +68,23 @@ export function FormAdicionarAluno({ coordenadorId, onCadastrado, existe }: Form
   return (
     <section className="max-w-xl">
       {sucesso && (
-        <div className="mb-6 inline-flex items-start gap-2 text-xs font-semibold text-green-700 bg-green-50 border border-green-200 rounded-lg px-4 py-3">
+        <div className="mb-6 inline-flex items-start gap-2 text-xs font-semibold text-green-700 dark:text-green-300 bg-green-50 dark:bg-green-900/30 border border-green-200 dark:border-green-800 rounded-lg px-4 py-3">
           <span>{sucesso}</span>
         </div>
       )}
 
-      <div className="bg-white border border-gray-200 rounded-2xl shadow-soft-xl overflow-hidden">
+      <div className="bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 rounded-2xl shadow-soft-xl overflow-hidden">
         <div className="px-6 sm:px-7 pt-5 sm:pt-6">
           <div className="inline-flex items-center gap-2 mb-5">
             <span className={dotClass} />
             <span className={labelClass}>Vincular aluno</span>
           </div>
           <header>
-            <h2 className="text-xl sm:text-2xl font-bold text-gray-900 tracking-tighter-2 leading-tight">
+            <h2 className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-slate-100 tracking-tighter-2 leading-tight">
               Cadastre um novo aluno<br/>
               <span className="text-gradient-warm">para vinculá-lo à sua coordenação.</span>
             </h2>
-            <p className="text-sm text-gray-500 mt-2 max-w-md">
+            <p className="text-sm text-gray-500 dark:text-slate-400 mt-2 max-w-md">
               Preencha os dados abaixo. O aluno receberá as credenciais para acessar o sistema.
             </p>
           </header>
@@ -101,7 +101,7 @@ export function FormAdicionarAluno({ coordenadorId, onCadastrado, existe }: Form
               placeholder="Nome completo do aluno"
             />
             {errors.nome && (
-              <p className="text-xs text-red-600 mt-1">{errors.nome.message}</p>
+              <p className="text-xs text-red-600 dark:text-red-400 mt-1">{errors.nome.message}</p>
             )}
           </section>
 
@@ -115,7 +115,7 @@ export function FormAdicionarAluno({ coordenadorId, onCadastrado, existe }: Form
               placeholder="Número de matrícula"
             />
             {errors.matricula && (
-              <p className="text-xs text-red-600 mt-1">{errors.matricula.message}</p>
+              <p className="text-xs text-red-600 dark:text-red-400 mt-1">{errors.matricula.message}</p>
             )}
           </section>
 
@@ -129,7 +129,7 @@ export function FormAdicionarAluno({ coordenadorId, onCadastrado, existe }: Form
               placeholder="email@instituto.edu"
             />
             {errors.email && (
-              <p className="text-xs text-red-600 mt-1">{errors.email.message}</p>
+              <p className="text-xs text-red-600 dark:text-red-400 mt-1">{errors.email.message}</p>
             )}
           </section>
 
@@ -143,18 +143,18 @@ export function FormAdicionarAluno({ coordenadorId, onCadastrado, existe }: Form
               placeholder="Senha de acesso"
             />
             {errors.senha && (
-              <p className="text-xs text-red-600 mt-1">{errors.senha.message}</p>
+              <p className="text-xs text-red-600 dark:text-red-400 mt-1">{errors.senha.message}</p>
             )}
           </section>
 
           {erro && (
-            <div className="inline-flex items-start gap-2 text-xs font-semibold text-rose-700 bg-rose-50 border border-rose-200 rounded-lg px-3 py-2">
+            <div className="inline-flex items-start gap-2 text-xs font-semibold text-rose-700 dark:text-rose-300 bg-rose-50 dark:bg-rose-900/30 border border-rose-200 dark:border-rose-800 rounded-lg px-3 py-2">
               <AlertCircle className="w-4 h-4 mt-px shrink-0" />
               <span>{erro}</span>
             </div>
           )}
 
-          <footer className="flex items-center justify-end gap-3 py-4 mt-3 border-t border-gray-100 bg-gradient-to-b from-white to-brand-surface/40 -mx-6 sm:-mx-7 px-6 sm:px-7">
+          <footer className="flex items-center justify-end gap-3 py-4 mt-3 border-t border-gray-100 dark:border-slate-700 bg-gradient-to-b from-white to-brand-surface/40 dark:from-slate-800 dark:to-slate-900/40 -mx-6 sm:-mx-7 px-6 sm:px-7">
             <button type="submit" disabled={isSubmitting} className={btnPrimaryClass}>
               <Plus className="w-4 h-4" />
               Cadastrar Aluno

--- a/clarify-next/src/components/coordenador/ModalConfirmarExclusao.tsx
+++ b/clarify-next/src/components/coordenador/ModalConfirmarExclusao.tsx
@@ -20,17 +20,17 @@ export function ModalConfirmarExclusao({ open, onClose, onConfirmar, nomeTurma }
 
         <div className="px-5 sm:px-7 pb-6 sm:pb-8">
           <div className="flex items-center gap-3 mb-4">
-            <div className="w-10 h-10 rounded-xl bg-red-50 flex items-center justify-center">
-              <AlertTriangle className="w-5 h-5 text-red-600" />
+            <div className="w-10 h-10 rounded-xl bg-red-50 dark:bg-red-900/30 flex items-center justify-center">
+              <AlertTriangle className="w-5 h-5 text-red-600 dark:text-red-400" />
             </div>
             <div>
-              <h2 className="text-xl font-bold text-gray-900">Excluir turma</h2>
-              <p className="text-xs text-gray-500">Esta ação não pode ser desfeita</p>
+              <h2 className="text-xl font-bold text-gray-900 dark:text-slate-100">Excluir turma</h2>
+              <p className="text-xs text-gray-500 dark:text-slate-400">Esta ação não pode ser desfeita</p>
             </div>
           </div>
 
-          <p className="text-sm text-gray-600">
-            Tem certeza que deseja excluir a turma <span className="font-semibold text-gray-900">{nomeTurma}</span>?
+          <p className="text-sm text-gray-600 dark:text-slate-300">
+            Tem certeza que deseja excluir a turma <span className="font-semibold text-gray-900 dark:text-slate-100">{nomeTurma}</span>?
             Todos os alunos vinculados serão removidos da turma.
           </p>
         </div>
@@ -39,7 +39,7 @@ export function ModalConfirmarExclusao({ open, onClose, onConfirmar, nomeTurma }
           <button
             type="button"
             onClick={onClose}
-            className="inline-flex items-center gap-1.5 bg-transparent text-[rgba(15,23,42,0.65)] font-semibold text-sm py-3 px-4 rounded-xl hover:bg-[rgba(15,23,42,0.05)] hover:text-[#0f172a] transition-[background-color,color] duration-180 cursor-pointer"
+            className="inline-flex items-center gap-1.5 bg-transparent text-[rgba(15,23,42,0.65)] dark:text-slate-300 font-semibold text-sm py-3 px-4 rounded-xl hover:bg-[rgba(15,23,42,0.05)] dark:hover:bg-slate-700 hover:text-[#0f172a] dark:hover:text-slate-100 transition-[background-color,color] duration-180 cursor-pointer"
           >
             Cancelar
           </button>

--- a/clarify-next/src/components/coordenador/ModalCriarTurma.tsx
+++ b/clarify-next/src/components/coordenador/ModalCriarTurma.tsx
@@ -16,10 +16,10 @@ interface ModalCriarTurmaProps {
   onCreate: (dados: { nome: string; disciplina: string; alunos: string[] }) => Promise<void>;
 }
 
-const labelClass = "text-[0.6875rem] font-bold tracking-[0.18em] uppercase text-[rgba(15,23,42,0.45)]";
-const inputClass = "w-full bg-transparent border-0 border-b-[1.5px] border-[rgba(15,23,42,0.10)] py-2 px-0 text-lg leading-[1.3] -tracking-[0.01em] text-[#0f172a] placeholder:text-[rgba(15,23,42,0.30)] placeholder:font-normal focus:outline-none focus:border-b-[#ca5f15] transition-[border-color] duration-180";
+const labelClass = "text-[0.6875rem] font-bold tracking-[0.18em] uppercase text-[rgba(15,23,42,0.45)] dark:text-slate-400";
+const inputClass = "w-full bg-transparent border-0 border-b-[1.5px] border-[rgba(15,23,42,0.10)] dark:border-slate-700 py-2 px-0 text-lg leading-[1.3] -tracking-[0.01em] text-[#0f172a] dark:text-slate-100 placeholder:text-[rgba(15,23,42,0.30)] dark:placeholder:text-slate-500 placeholder:font-normal focus:outline-none focus:border-b-[#ca5f15] transition-[border-color] duration-180";
 const btnPrimaryClass = "inline-flex items-center gap-2 bg-[#ca5f15] text-white font-bold text-sm -tracking-[0.005em] py-3 px-5 rounded-xl shadow-[inset_0_1px_0_rgba(255,255,255,0.18),_0_1px_2px_rgba(202,95,21,0.30),_0_10px_24px_-10px_rgba(202,95,21,0.55)] hover:bg-[#b35211] hover:-translate-y-px active:translate-y-0 disabled:bg-[rgba(15,23,42,0.10)] disabled:text-[rgba(15,23,42,0.35)] disabled:shadow-none disabled:cursor-not-allowed disabled:transform-none transition-[transform,box-shadow,background-color] duration-180 cursor-pointer";
-const btnGhostClass = "inline-flex items-center gap-1.5 bg-transparent text-[rgba(15,23,42,0.65)] font-semibold text-sm py-3 px-4 rounded-xl hover:bg-[rgba(15,23,42,0.05)] hover:text-[#0f172a] transition-[background-color,color] duration-180 cursor-pointer";
+const btnGhostClass = "inline-flex items-center gap-1.5 bg-transparent text-[rgba(15,23,42,0.65)] dark:text-slate-300 font-semibold text-sm py-3 px-4 rounded-xl hover:bg-[rgba(15,23,42,0.05)] dark:hover:bg-slate-700 hover:text-[#0f172a] dark:hover:text-slate-100 transition-[background-color,color] duration-180 cursor-pointer";
 
 export function ModalCriarTurma({ open, onClose, onCreate }: ModalCriarTurmaProps) {
   const { usuario } = useAuth();
@@ -115,8 +115,8 @@ export function ModalCriarTurma({ open, onClose, onCreate }: ModalCriarTurmaProp
               <Users className="w-5 h-5 text-brand-primary" />
             </div>
             <div>
-              <h2 className="text-xl font-bold text-gray-900">Nova turma</h2>
-              <p className="text-xs text-gray-500">Preencha os dados e adicione alunos</p>
+              <h2 className="text-xl font-bold text-gray-900 dark:text-slate-100">Nova turma</h2>
+              <p className="text-xs text-gray-500 dark:text-slate-400">Preencha os dados e adicione alunos</p>
             </div>
           </div>
 
@@ -131,7 +131,7 @@ export function ModalCriarTurma({ open, onClose, onCreate }: ModalCriarTurmaProp
                 className={cn(inputClass, "font-semibold mt-1")}
               />
               {errors.nome && (
-                <p className="text-xs text-red-600 mt-1">{errors.nome.message}</p>
+                <p className="text-xs text-red-600 dark:text-red-400 mt-1">{errors.nome.message}</p>
               )}
             </div>
 
@@ -145,7 +145,7 @@ export function ModalCriarTurma({ open, onClose, onCreate }: ModalCriarTurmaProp
                 className={cn(inputClass, "font-semibold mt-1")}
               />
               {errors.disciplina && (
-                <p className="text-xs text-red-600 mt-1">{errors.disciplina.message}</p>
+                <p className="text-xs text-red-600 dark:text-red-400 mt-1">{errors.disciplina.message}</p>
               )}
             </div>
 
@@ -154,28 +154,28 @@ export function ModalCriarTurma({ open, onClose, onCreate }: ModalCriarTurmaProp
               <button
                 type="button"
                 onClick={() => setDropdownOpen(!dropdownOpen)}
-                className="w-full flex items-center justify-between gap-2 bg-transparent border border-gray-200 rounded-xl py-2.5 px-3 text-sm text-left"
+                className="w-full flex items-center justify-between gap-2 bg-transparent border border-gray-200 dark:border-slate-700 rounded-xl py-2.5 px-3 text-sm text-left"
               >
-                <span className={alunos.length === 0 ? "text-gray-400" : "text-gray-900 font-medium"}>
+                <span className={alunos.length === 0 ? "text-gray-400 dark:text-slate-500" : "text-gray-900 dark:text-slate-100 font-medium"}>
                   {alunos.length === 0
                     ? "Selecionar alunos..."
                     : `${alunos.length} aluno${alunos.length !== 1 ? 's' : ''} selecionado${alunos.length !== 1 ? 's' : ''}`}
                 </span>
-                <ChevronDown className={cn("w-4 h-4 text-gray-400 transition-transform duration-180", dropdownOpen && "rotate-180")} />
+                <ChevronDown className={cn("w-4 h-4 text-gray-400 dark:text-slate-500 transition-transform duration-180", dropdownOpen && "rotate-180")} />
               </button>
 
               {dropdownOpen && (
-                <div className="absolute z-10 mt-1 w-full border border-gray-200 rounded-xl bg-white shadow-lg max-h-48 overflow-y-auto">
+                <div className="absolute z-10 mt-1 w-full border border-gray-200 dark:border-slate-700 rounded-xl bg-white dark:bg-slate-800 shadow-lg max-h-48 overflow-y-auto">
                   {loadingAlunos ? (
-                    <div className="p-3 text-xs text-gray-400">Carregando alunos...</div>
+                    <div className="p-3 text-xs text-gray-400 dark:text-slate-400">Carregando alunos...</div>
                   ) : alunosDoCoord.length === 0 ? (
-                    <div className="p-3 text-xs text-gray-400">Nenhum aluno vinculado. Cadastre alunos primeiro.</div>
+                    <div className="p-3 text-xs text-gray-400 dark:text-slate-400">Nenhum aluno vinculado. Cadastre alunos primeiro.</div>
                   ) : alunosDoCoord.map((aluno) => {
                     const isSelected = alunos.includes(aluno.id);
                     return (
                       <label
                         key={aluno.id}
-                        className="flex items-center gap-3 px-3 py-2 hover:bg-[rgba(202,95,21,0.05)] cursor-pointer border-b border-gray-100 last:border-b-0"
+                        className="flex items-center gap-3 px-3 py-2 hover:bg-[rgba(202,95,21,0.05)] dark:hover:bg-slate-700/50 cursor-pointer border-b border-gray-100 dark:border-slate-700 last:border-b-0"
                       >
                         <input
                           type="checkbox"
@@ -184,8 +184,8 @@ export function ModalCriarTurma({ open, onClose, onCreate }: ModalCriarTurmaProp
                           className="accent-[#ca5f15]"
                         />
                         <div className="flex-1 min-w-0">
-                          <p className="text-sm font-medium text-gray-900 truncate">{aluno.nome}</p>
-                          <p className="text-xs text-gray-400">{aluno.matricula}</p>
+                          <p className="text-sm font-medium text-gray-900 dark:text-slate-100 truncate">{aluno.nome}</p>
+                          <p className="text-xs text-gray-400 dark:text-slate-400">{aluno.matricula}</p>
                         </div>
                       </label>
                     );
@@ -194,11 +194,11 @@ export function ModalCriarTurma({ open, onClose, onCreate }: ModalCriarTurmaProp
               )}
             </div>
 
-            <div className="border border-gray-200 rounded-xl p-3 min-h-[64px]">
-              <p className="text-xs text-gray-400 mb-2">Alunos adicionados ({alunos.length})</p>
+            <div className="border border-gray-200 dark:border-slate-700 rounded-xl p-3 min-h-[64px]">
+              <p className="text-xs text-gray-400 dark:text-slate-400 mb-2">Alunos adicionados ({alunos.length})</p>
               <div className="flex flex-wrap gap-2">
                 {alunos.length === 0 && (
-                  <span className="text-xs text-gray-300">Nenhum aluno selecionado</span>
+                  <span className="text-xs text-gray-300 dark:text-slate-500">Nenhum aluno selecionado</span>
                 )}
                 {alunos.map((alunoId) => {
                   const info = alunosMap.get(alunoId);
@@ -222,7 +222,7 @@ export function ModalCriarTurma({ open, onClose, onCreate }: ModalCriarTurmaProp
             </div>
 
             {erroCriar && (
-              <p className="text-xs text-red-600 bg-red-50 border border-red-200 rounded-lg px-3 py-2">
+              <p className="text-xs text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 rounded-lg px-3 py-2">
                 {erroCriar}
               </p>
             )}

--- a/clarify-next/src/components/coordenador/ModalEditarTurma.tsx
+++ b/clarify-next/src/components/coordenador/ModalEditarTurma.tsx
@@ -16,10 +16,10 @@ interface ModalEditarTurmaProps {
   onSalvar: (id: string, dados: { nome: string; disciplina: string; alunos: string[] }) => Promise<void>;
 }
 
-const labelClass = "text-[0.6875rem] font-bold tracking-[0.18em] uppercase text-[rgba(15,23,42,0.45)]";
-const inputClass = "w-full bg-transparent border-0 border-b-[1.5px] border-[rgba(15,23,42,0.10)] py-2 px-0 text-lg leading-[1.3] -tracking-[0.01em] text-[#0f172a] placeholder:text-[rgba(15,23,42,0.30)] placeholder:font-normal focus:outline-none focus:border-b-[#ca5f15] transition-[border-color] duration-180";
+const labelClass = "text-[0.6875rem] font-bold tracking-[0.18em] uppercase text-[rgba(15,23,42,0.45)] dark:text-slate-400";
+const inputClass = "w-full bg-transparent border-0 border-b-[1.5px] border-[rgba(15,23,42,0.10)] dark:border-slate-700 py-2 px-0 text-lg leading-[1.3] -tracking-[0.01em] text-[#0f172a] dark:text-slate-100 placeholder:text-[rgba(15,23,42,0.30)] dark:placeholder:text-slate-500 placeholder:font-normal focus:outline-none focus:border-b-[#ca5f15] transition-[border-color] duration-180";
 const btnPrimaryClass = "inline-flex items-center gap-2 bg-[#ca5f15] text-white font-bold text-sm -tracking-[0.005em] py-3 px-5 rounded-xl shadow-[inset_0_1px_0_rgba(255,255,255,0.18),_0_1px_2px_rgba(202,95,21,0.30),_0_10px_24px_-10px_rgba(202,95,21,0.55)] hover:bg-[#b35211] hover:-translate-y-px active:translate-y-0 disabled:bg-[rgba(15,23,42,0.10)] disabled:text-[rgba(15,23,42,0.35)] disabled:shadow-none disabled:cursor-not-allowed disabled:transform-none transition-[transform,box-shadow,background-color] duration-180 cursor-pointer";
-const btnGhostClass = "inline-flex items-center gap-1.5 bg-transparent text-[rgba(15,23,42,0.65)] font-semibold text-sm py-3 px-4 rounded-xl hover:bg-[rgba(15,23,42,0.05)] hover:text-[#0f172a] transition-[background-color,color] duration-180 cursor-pointer";
+const btnGhostClass = "inline-flex items-center gap-1.5 bg-transparent text-[rgba(15,23,42,0.65)] dark:text-slate-300 font-semibold text-sm py-3 px-4 rounded-xl hover:bg-[rgba(15,23,42,0.05)] dark:hover:bg-slate-700 hover:text-[#0f172a] dark:hover:text-slate-100 transition-[background-color,color] duration-180 cursor-pointer";
 
 export function ModalEditarTurma({ open, turma, onClose, onSalvar }: ModalEditarTurmaProps) {
   const {
@@ -101,8 +101,8 @@ export function ModalEditarTurma({ open, turma, onClose, onSalvar }: ModalEditar
               <Users className="w-5 h-5 text-brand-primary" />
             </div>
             <div>
-              <h2 className="text-xl font-bold text-gray-900">Editar turma</h2>
-              <p className="text-xs text-gray-500">Altere os dados e os alunos vinculados</p>
+              <h2 className="text-xl font-bold text-gray-900 dark:text-slate-100">Editar turma</h2>
+              <p className="text-xs text-gray-500 dark:text-slate-400">Altere os dados e os alunos vinculados</p>
             </div>
           </div>
 
@@ -117,7 +117,7 @@ export function ModalEditarTurma({ open, turma, onClose, onSalvar }: ModalEditar
                 className={cn(inputClass, "font-semibold mt-1")}
               />
               {errors.nome && (
-                <p className="text-xs text-red-600 mt-1">{errors.nome.message}</p>
+                <p className="text-xs text-red-600 dark:text-red-400 mt-1">{errors.nome.message}</p>
               )}
             </div>
 
@@ -131,7 +131,7 @@ export function ModalEditarTurma({ open, turma, onClose, onSalvar }: ModalEditar
                 className={cn(inputClass, "font-semibold mt-1")}
               />
               {errors.disciplina && (
-                <p className="text-xs text-red-600 mt-1">{errors.disciplina.message}</p>
+                <p className="text-xs text-red-600 dark:text-red-400 mt-1">{errors.disciplina.message}</p>
               )}
             </div>
 
@@ -158,11 +158,11 @@ export function ModalEditarTurma({ open, turma, onClose, onSalvar }: ModalEditar
               </div>
             </div>
 
-            <div className="border border-gray-200 rounded-xl p-3 min-h-[64px]">
-              <p className="text-xs text-gray-400 mb-2">Alunos adicionados</p>
+            <div className="border border-gray-200 dark:border-slate-700 rounded-xl p-3 min-h-[64px]">
+              <p className="text-xs text-gray-400 dark:text-slate-400 mb-2">Alunos adicionados</p>
               <div className="flex flex-wrap gap-2">
                 {alunos.length === 0 && (
-                  <span className="text-xs text-gray-300">Nenhum aluno adicionado</span>
+                  <span className="text-xs text-gray-300 dark:text-slate-500">Nenhum aluno adicionado</span>
                 )}
                 {alunos.map((matricula, index) => (
                   <span
@@ -183,7 +183,7 @@ export function ModalEditarTurma({ open, turma, onClose, onSalvar }: ModalEditar
             </div>
 
             {erroSalvar && (
-              <p className="text-xs text-red-600 bg-red-50 border border-red-200 rounded-lg px-3 py-2">
+              <p className="text-xs text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 rounded-lg px-3 py-2">
                 {erroSalvar}
               </p>
             )}

--- a/clarify-next/src/components/coordenador/ModalFeedback.tsx
+++ b/clarify-next/src/components/coordenador/ModalFeedback.tsx
@@ -16,11 +16,11 @@ interface ModalFeedbackProps {
 
 const LIMITE_FEEDBACK = 200;
 
-const labelClass = "text-[0.6875rem] font-bold tracking-[0.18em] uppercase text-[rgba(15,23,42,0.45)]";
-const counterClass = "tabular-nums text-[0.6875rem] text-[rgba(15,23,42,0.40)] tracking-[0.04em]";
-const inputClass = "w-full bg-transparent border-0 border-b-[1.5px] border-[rgba(15,23,42,0.10)] py-2 px-0 text-lg leading-[1.3] -tracking-[0.01em] text-[#0f172a] placeholder:text-[rgba(15,23,42,0.30)] placeholder:font-normal focus:outline-none focus:border-b-[#ca5f15] transition-[border-color] duration-180";
+const labelClass = "text-[0.6875rem] font-bold tracking-[0.18em] uppercase text-[rgba(15,23,42,0.45)] dark:text-slate-400";
+const counterClass = "tabular-nums text-[0.6875rem] text-[rgba(15,23,42,0.40)] dark:text-slate-400 tracking-[0.04em]";
+const inputClass = "w-full bg-transparent border-0 border-b-[1.5px] border-[rgba(15,23,42,0.10)] dark:border-slate-700 py-2 px-0 text-lg leading-[1.3] -tracking-[0.01em] text-[#0f172a] dark:text-slate-100 placeholder:text-[rgba(15,23,42,0.30)] dark:placeholder:text-slate-500 placeholder:font-normal focus:outline-none focus:border-b-[#ca5f15] transition-[border-color] duration-180";
 const btnPrimaryClass = "inline-flex items-center gap-2 bg-[#ca5f15] text-white font-bold text-sm -tracking-[0.005em] py-3 px-5 rounded-xl shadow-[inset_0_1px_0_rgba(255,255,255,0.18),_0_1px_2px_rgba(202,95,21,0.30),_0_10px_24px_-10px_rgba(202,95,21,0.55)] hover:bg-[#b35211] hover:-translate-y-px active:translate-y-0 disabled:bg-[rgba(15,23,42,0.10)] disabled:text-[rgba(15,23,42,0.35)] disabled:shadow-none disabled:cursor-not-allowed disabled:transform-none transition-[transform,box-shadow,background-color] duration-180 cursor-pointer";
-const btnGhostClass = "inline-flex items-center gap-1.5 bg-transparent text-[rgba(15,23,42,0.65)] font-semibold text-sm py-3 px-4 rounded-xl hover:bg-[rgba(15,23,42,0.05)] hover:text-[#0f172a] transition-[background-color,color] duration-180 cursor-pointer";
+const btnGhostClass = "inline-flex items-center gap-1.5 bg-transparent text-[rgba(15,23,42,0.65)] dark:text-slate-300 font-semibold text-sm py-3 px-4 rounded-xl hover:bg-[rgba(15,23,42,0.05)] dark:hover:bg-slate-700 hover:text-[#0f172a] dark:hover:text-slate-100 transition-[background-color,color] duration-180 cursor-pointer";
 
 export function ModalFeedback({ open, onClose, onSubmit }: ModalFeedbackProps) {
   const {
@@ -63,8 +63,8 @@ export function ModalFeedback({ open, onClose, onSubmit }: ModalFeedbackProps) {
               <MessageSquareText className="w-5 h-5 text-brand-primary" />
             </div>
             <div>
-              <h2 className="text-xl font-bold text-gray-900">Feedback</h2>
-              <p className="text-xs text-gray-500">Descreva o motivo da reprovação ou o ajuste necessário.</p>
+              <h2 className="text-xl font-bold text-gray-900 dark:text-slate-100">Feedback</h2>
+              <p className="text-xs text-gray-500 dark:text-slate-400">Descreva o motivo da reprovação ou o ajuste necessário.</p>
             </div>
           </div>
 
@@ -85,7 +85,7 @@ export function ModalFeedback({ open, onClose, onSubmit }: ModalFeedbackProps) {
                 className={cn(inputClass, "font-semibold mt-1")}
               />
               {errors.texto && (
-                <p className="text-xs text-red-600 mt-1">{errors.texto.message}</p>
+                <p className="text-xs text-red-600 dark:text-red-400 mt-1">{errors.texto.message}</p>
               )}
             </div>
 

--- a/clarify-next/src/components/demandas/BarraFiltros.tsx
+++ b/clarify-next/src/components/demandas/BarraFiltros.tsx
@@ -27,25 +27,25 @@ export function BarraFiltros({
   const temFiltro = busca.trim() !== '' || status !== 'todos';
 
   return (
-    <div className="bg-white rounded-xl border border-gray-200 p-3.5 flex flex-wrap gap-2 items-center">
+    <div className="bg-white dark:bg-slate-800 rounded-xl border border-gray-200 dark:border-slate-700 p-3.5 flex flex-wrap gap-2 items-center">
       <div className="flex-1 min-w-[180px] relative">
-        <Search className="w-3.5 h-3.5 text-gray-400 absolute left-2.5 top-1/2 -translate-y-1/2 pointer-events-none" />
+        <Search className="w-3.5 h-3.5 text-gray-400 dark:text-slate-500 absolute left-2.5 top-1/2 -translate-y-1/2 pointer-events-none" />
         <input
           type="text"
           value={busca}
           onChange={(e) => onBuscaChange(e.target.value)}
           placeholder="Pesquisar protocolo ou tipo..."
           aria-label="Pesquisar protocolo ou tipo"
-          className="w-full pl-8 pr-3 py-2 border border-gray-200 rounded-lg bg-gray-50 text-sm outline-none focus:border-brand-primary focus:bg-white transition-colors"
+          className="w-full pl-8 pr-3 py-2 border border-gray-200 dark:border-slate-700 rounded-lg bg-gray-50 dark:bg-slate-900 text-sm dark:text-slate-100 dark:placeholder:text-slate-500 outline-none focus:border-brand-primary focus:bg-white dark:focus:bg-slate-800 transition-colors"
         />
       </div>
 
       <div className="relative">
-        <SlidersHorizontal className="w-3.5 h-3.5 text-gray-400 absolute left-2.5 top-1/2 -translate-y-1/2 pointer-events-none" />
+        <SlidersHorizontal className="w-3.5 h-3.5 text-gray-400 dark:text-slate-500 absolute left-2.5 top-1/2 -translate-y-1/2 pointer-events-none" />
         <select
           value={status}
           onChange={(e) => onStatusChange(e.target.value as StatusDemanda | 'todos')}
-          className="pl-8 pr-7 py-2 border border-gray-200 rounded-lg bg-gray-50 text-sm appearance-none cursor-pointer outline-none focus:border-brand-primary focus:bg-white transition-colors"
+          className="pl-8 pr-7 py-2 border border-gray-200 dark:border-slate-700 rounded-lg bg-gray-50 dark:bg-slate-900 text-sm dark:text-slate-100 appearance-none cursor-pointer outline-none focus:border-brand-primary focus:bg-white dark:focus:bg-slate-800 transition-colors"
         >
           {OPCOES_STATUS.map((op) => (
             <option key={op.valor} value={op.valor}>

--- a/clarify-next/src/components/demandas/CardDemanda.tsx
+++ b/clarify-next/src/components/demandas/CardDemanda.tsx
@@ -25,7 +25,7 @@ export function CardDemanda({ demanda, onVerDetalhes }: CardDemandaProps) {
   return (
     <Card className="p-4 sm:p-5 flex flex-col gap-3 hover:shadow-md hover:-translate-y-0.5 transition-all">
       <div className="flex items-center justify-between gap-2">
-        <span className="text-xs font-semibold text-gray-500 tracking-wider">
+        <span className="text-xs font-semibold text-gray-500 dark:text-slate-400 tracking-wider">
           #{demanda.protocolo}
         </span>
         <div className="flex items-center gap-2">
@@ -41,15 +41,15 @@ export function CardDemanda({ demanda, onVerDetalhes }: CardDemandaProps) {
       </div>
 
       <div className="min-w-0">
-        <h3 className="text-base font-bold text-gray-900 break-words [overflow-wrap:anywhere]">
+        <h3 className="text-base font-bold text-gray-900 dark:text-slate-100 break-words [overflow-wrap:anywhere]">
           {demanda.tipo}
         </h3>
-        <p className="text-sm text-gray-600 mt-1 line-clamp-2 break-words [overflow-wrap:anywhere]">
+        <p className="text-sm text-gray-600 dark:text-slate-300 mt-1 line-clamp-2 break-words [overflow-wrap:anywhere]">
           {demanda.descricao}
         </p>
       </div>
 
-      <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-gray-500 pt-2 border-t border-gray-100">
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-gray-500 dark:text-slate-400 pt-2 border-t border-gray-100 dark:border-slate-700">
         <span className="inline-flex items-center gap-1.5">
           <Calendar className="w-3.5 h-3.5" />
           {formatarData(demanda.dataCriacao)}
@@ -61,8 +61,8 @@ export function CardDemanda({ demanda, onVerDetalhes }: CardDemandaProps) {
       </div>
 
       {demanda.feedback && (
-        <div className="text-xs bg-gray-50 border border-gray-100 rounded-md p-2 text-gray-700">
-          <strong className="text-gray-900">Observação:</strong> {demanda.feedback}
+        <div className="text-xs bg-gray-50 dark:bg-slate-900 border border-gray-100 dark:border-slate-700 rounded-md p-2 text-gray-700 dark:text-slate-300">
+          <strong className="text-gray-900 dark:text-slate-100">Observação:</strong> {demanda.feedback}
         </div>
       )}
 

--- a/clarify-next/src/components/demandas/CardHistorico.tsx
+++ b/clarify-next/src/components/demandas/CardHistorico.tsx
@@ -10,9 +10,9 @@ interface CardHistoricoProps {
 
 export function CardHistorico({ demanda }: CardHistoricoProps) {
   return (
-    <article className="bg-white rounded-xl border border-gray-200 p-4 flex flex-col gap-2">
+    <article className="bg-white dark:bg-slate-800 rounded-xl border border-gray-200 dark:border-slate-700 p-4 flex flex-col gap-2">
       <div className="flex items-center justify-between gap-2">
-        <span className="text-xs font-semibold text-gray-500 tracking-wider">
+        <span className="text-xs font-semibold text-gray-500 dark:text-slate-400 tracking-wider">
           #{demanda.protocolo}
         </span>
         <span
@@ -21,10 +21,10 @@ export function CardHistorico({ demanda }: CardHistoricoProps) {
           {obterLabelStatus(demanda.status)}
         </span>
       </div>
-      <h4 className="text-sm font-bold text-gray-900 break-words [overflow-wrap:anywhere]">
+      <h4 className="text-sm font-bold text-gray-900 dark:text-slate-100 break-words [overflow-wrap:anywhere]">
         {demanda.tipo}
       </h4>
-      <span className="inline-flex items-center gap-1.5 text-xs text-gray-500">
+      <span className="inline-flex items-center gap-1.5 text-xs text-gray-500 dark:text-slate-400">
         <Clock className="w-3.5 h-3.5" />
         Concluído em {formatarData(demanda.dataAtualizacao)}
       </span>

--- a/clarify-next/src/components/demandas/CardNovaDemanda.tsx
+++ b/clarify-next/src/components/demandas/CardNovaDemanda.tsx
@@ -11,9 +11,9 @@ export function CardNovaDemanda({ onClick }: CardNovaDemandaProps) {
     <button
       type="button"
       onClick={onClick}
-      className="border-2 border-dashed border-gray-300 rounded-xl p-5 flex flex-col items-center justify-center gap-2 text-gray-500 hover:border-brand-primary hover:text-brand-primary hover:bg-white transition-colors min-h-[180px] cursor-pointer bg-transparent w-full"
+      className="border-2 border-dashed border-gray-300 dark:border-slate-600 rounded-xl p-5 flex flex-col items-center justify-center gap-2 text-gray-500 dark:text-slate-400 hover:border-brand-primary hover:text-brand-primary hover:bg-white dark:hover:bg-slate-800 transition-colors min-h-[180px] cursor-pointer bg-transparent w-full"
     >
-      <span className="w-10 h-10 rounded-full bg-gray-100 flex items-center justify-center">
+      <span className="w-10 h-10 rounded-full bg-gray-100 dark:bg-slate-700 flex items-center justify-center">
         <Plus className="w-5 h-5" />
       </span>
       <span className="text-sm font-bold">Nova Solicitação</span>

--- a/clarify-next/src/components/demandas/EstadoVazio.tsx
+++ b/clarify-next/src/components/demandas/EstadoVazio.tsx
@@ -1,8 +1,8 @@
 export function EstadoVazio() {
   return (
-    <div className="col-span-full bg-white border-2 border-dashed border-gray-300 rounded-xl p-8 sm:p-10 text-center">
-      <h3 className="text-base font-bold text-gray-900">Você ainda não possui solicitações</h3>
-      <p className="text-sm text-gray-500 mt-1">
+    <div className="col-span-full bg-white dark:bg-slate-800 border-2 border-dashed border-gray-300 dark:border-slate-600 rounded-xl p-8 sm:p-10 text-center">
+      <h3 className="text-base font-bold text-gray-900 dark:text-slate-100">Você ainda não possui solicitações</h3>
+      <p className="text-sm text-gray-500 dark:text-slate-400 mt-1">
         Quando você abrir uma demanda, ela aparecerá aqui para acompanhamento.
       </p>
     </div>

--- a/clarify-next/src/components/demandas/LinhaHistorico.tsx
+++ b/clarify-next/src/components/demandas/LinhaHistorico.tsx
@@ -9,11 +9,11 @@ interface LinhaHistoricoProps {
 
 export function LinhaHistorico({ demanda }: LinhaHistoricoProps) {
   return (
-    <tr className="border-t border-gray-100">
-      <td className="py-3 text-xs font-semibold text-gray-500">
+    <tr className="border-t border-gray-100 dark:border-slate-700">
+      <td className="py-3 text-xs font-semibold text-gray-500 dark:text-slate-400">
         #{demanda.protocolo}
       </td>
-      <td className="py-3 text-sm text-gray-900 break-words [overflow-wrap:anywhere]">
+      <td className="py-3 text-sm text-gray-900 dark:text-slate-100 break-words [overflow-wrap:anywhere]">
         {demanda.tipo}
       </td>
       <td className="py-3">
@@ -23,7 +23,7 @@ export function LinhaHistorico({ demanda }: LinhaHistoricoProps) {
           {obterLabelStatus(demanda.status)}
         </span>
       </td>
-      <td className="py-3 text-xs text-gray-500">
+      <td className="py-3 text-xs text-gray-500 dark:text-slate-400">
         {formatarData(demanda.dataAtualizacao)}
       </td>
     </tr>

--- a/clarify-next/src/components/demandas/ModalDetalhesDemanda.tsx
+++ b/clarify-next/src/components/demandas/ModalDetalhesDemanda.tsx
@@ -32,9 +32,9 @@ function diasDesde(dataISO: string): number | null {
   return Math.max(0, Math.round(diffMs / (1000 * 60 * 60 * 24)));
 }
 
-const labelClass = "text-[0.6875rem] font-bold tracking-[0.18em] uppercase text-[rgba(15,23,42,0.45)]";
+const labelClass = "text-[0.6875rem] font-bold tracking-[0.18em] uppercase text-[rgba(15,23,42,0.45)] dark:text-slate-400";
 const dotClass = "inline-block w-1.5 h-1.5 rounded-full bg-[#ca5f15] shadow-[0_0_0_3px_rgba(202,95,21,0.18)]";
-const btnGhostClass = "inline-flex items-center gap-1.5 bg-transparent text-[rgba(15,23,42,0.65)] font-semibold text-sm py-3 px-4 rounded-xl hover:bg-[rgba(15,23,42,0.05)] hover:text-[#0f172a] transition-[background-color,color] duration-180 cursor-pointer";
+const btnGhostClass = "inline-flex items-center gap-1.5 bg-transparent text-[rgba(15,23,42,0.65)] dark:text-slate-300 font-semibold text-sm py-3 px-4 rounded-xl hover:bg-[rgba(15,23,42,0.05)] dark:hover:bg-slate-700 hover:text-[#0f172a] dark:hover:text-slate-100 transition-[background-color,color] duration-180 cursor-pointer";
 const staggerClass = "stagger-container";
 
 export function ModalDetalhesDemanda({ open, onClose, demanda, remetente }: ModalDetalhesDemandaProps) {
@@ -60,11 +60,11 @@ export function ModalDetalhesDemanda({ open, onClose, demanda, remetente }: Moda
           <div className={cn("px-5 sm:px-7 pt-4 sm:pt-5 pb-2", staggerClass)}>
             <header className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
               <div className="min-w-0 flex-1">
-                <h2 className="text-xl sm:text-2xl font-bold text-gray-900 tracking-tighter-2 leading-tight break-words [overflow-wrap:anywhere]">
+                <h2 className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-slate-100 tracking-tighter-2 leading-tight break-words [overflow-wrap:anywhere]">
                   {demanda.tipo}
                 </h2>
-                <p className="text-sm text-gray-500 mt-1.5">
-                  Aberta em <span className="font-semibold text-gray-700">{formatarData(demanda.dataCriacao)}</span>
+                <p className="text-sm text-gray-500 dark:text-slate-400 mt-1.5">
+                  Aberta em <span className="font-semibold text-gray-700 dark:text-slate-300">{formatarData(demanda.dataCriacao)}</span>
                   {dias !== null ? ` · há ${dias} dias` : ''}
                 </p>
               </div>
@@ -74,7 +74,7 @@ export function ModalDetalhesDemanda({ open, onClose, demanda, remetente }: Moda
               </Badge>
             </header>
 
-            <section className="mt-6 bg-gradient-to-br from-white to-brand-surface/50 rounded-2xl border border-gray-100 px-3 sm:px-6 py-4">
+            <section className="mt-6 bg-gradient-to-br from-white to-brand-surface/50 dark:from-slate-800 dark:to-slate-900 rounded-2xl border border-gray-100 dark:border-slate-700 px-3 sm:px-6 py-4">
               <TimelineProgresso status={demanda.status} />
             </section>
 
@@ -83,8 +83,8 @@ export function ModalDetalhesDemanda({ open, onClose, demanda, remetente }: Moda
                 <FileText className="w-3.5 h-3.5 text-brand-primary" />
                 <p className={labelClass}>Detalhes da solicitação</p>
               </div>
-              <Card className="bg-brand-surface/50 border-brand-surface-dim/40 rounded-2xl px-5 py-4 shadow-none">
-                <p className="text-[0.95rem] sm:text-base text-gray-800 leading-relaxed break-words [overflow-wrap:anywhere] whitespace-pre-wrap">
+              <Card className="bg-brand-surface/50 dark:bg-slate-900/50 border-brand-surface-dim/40 dark:border-slate-700 rounded-2xl px-5 py-4 shadow-none">
+                <p className="text-[0.95rem] sm:text-base text-gray-800 dark:text-slate-200 leading-relaxed break-words [overflow-wrap:anywhere] whitespace-pre-wrap">
                   {demanda.descricao}
                 </p>
               </Card>
@@ -92,13 +92,13 @@ export function ModalDetalhesDemanda({ open, onClose, demanda, remetente }: Moda
 
             <section className="mt-6">
               <p className={labelClass}>Enviado por</p>
-              <div className="mt-3 flex items-center gap-3 bg-brand-surface/60 rounded-2xl px-4 py-3 border border-gray-100">
+              <div className="mt-3 flex items-center gap-3 bg-brand-surface/60 dark:bg-slate-900/60 rounded-2xl px-4 py-3 border border-gray-100 dark:border-slate-700">
                 <div className="w-11 h-11 rounded-full bg-brand-primary text-white text-base font-bold flex items-center justify-center shrink-0 shadow-soft-md">
                   {inicialRemetente}
                 </div>
                 <div className="min-w-0">
-                  <p className="text-sm font-semibold text-gray-900 truncate">{nomeRemetente}</p>
-                  <p className="text-xs text-gray-500 truncate inline-flex items-center gap-1.5">
+                  <p className="text-sm font-semibold text-gray-900 dark:text-slate-100 truncate">{nomeRemetente}</p>
+                  <p className="text-xs text-gray-500 dark:text-slate-400 truncate inline-flex items-center gap-1.5">
                     <Hash className="w-3 h-3" />
                     {remetente?.matricula || demanda.alunoId.slice(0, 8)}
                     <span className="opacity-30">·</span>
@@ -112,15 +112,15 @@ export function ModalDetalhesDemanda({ open, onClose, demanda, remetente }: Moda
             <section className="mt-7 grid grid-cols-1 sm:grid-cols-2 gap-3">
               <Card className="rounded-2xl px-4 py-3 shadow-none">
                 <p className={labelClass}>Criada em</p>
-                <p className="text-sm font-semibold text-gray-900 mt-1 inline-flex items-center gap-1.5">
-                  <Calendar className="w-3.5 h-3.5 text-gray-400" />
+                <p className="text-sm font-semibold text-gray-900 dark:text-slate-100 mt-1 inline-flex items-center gap-1.5">
+                  <Calendar className="w-3.5 h-3.5 text-gray-400 dark:text-slate-500" />
                   {formatarData(demanda.dataCriacao)}
                 </p>
               </Card>
               <Card className="rounded-2xl px-4 py-3 shadow-none">
                 <p className={labelClass}>Status</p>
-                <p className="text-sm font-semibold text-gray-900 mt-1 inline-flex items-center gap-1.5">
-                  <Tag className="w-3.5 h-3.5 text-gray-400" />
+                <p className="text-sm font-semibold text-gray-900 dark:text-slate-100 mt-1 inline-flex items-center gap-1.5">
+                  <Tag className="w-3.5 h-3.5 text-gray-400 dark:text-slate-500" />
                   {statusLabel}
                 </p>
               </Card>
@@ -132,7 +132,7 @@ export function ModalDetalhesDemanda({ open, onClose, demanda, remetente }: Moda
                   <MessageSquareQuote className="w-3.5 h-3.5" />
                   Observação da coordenação
                 </p>
-                <div className="mt-3 bg-amber-50 border border-amber-200 rounded-2xl px-4 py-3 text-sm text-amber-900 leading-relaxed break-words [overflow-wrap:anywhere] whitespace-pre-wrap">
+                <div className="mt-3 bg-amber-50 dark:bg-amber-900/30 border border-amber-200 dark:border-amber-800 rounded-2xl px-4 py-3 text-sm text-amber-900 dark:text-amber-200 leading-relaxed break-words [overflow-wrap:anywhere] whitespace-pre-wrap">
                   {demanda.feedback}
                 </div>
               </section>

--- a/clarify-next/src/components/demandas/ModalNovaDemanda.tsx
+++ b/clarify-next/src/components/demandas/ModalNovaDemanda.tsx
@@ -63,14 +63,14 @@ export function ModalNovaDemanda({ open, onClose, usuario, onSubmit }: ModalNova
 
   const inicial = (usuario?.nome || 'V').charAt(0).toUpperCase();
 
-  const labelClass = "text-[0.6875rem] font-bold tracking-[0.18em] uppercase text-[rgba(15,23,42,0.45)]";
-  const inputClass = "w-full bg-transparent border-0 border-b-[1.5px] border-[rgba(15,23,42,0.10)] py-2 px-0 text-lg leading-[1.3] -tracking-[0.01em] text-[#0f172a] placeholder:text-[rgba(15,23,42,0.30)] placeholder:font-normal focus:outline-none focus:border-b-[#ca5f15] transition-[border-color] duration-180";
-  const textareaClass = "w-full resize-none border border-[rgba(15,23,42,0.10)] rounded-2xl p-4 text-[0.95rem] leading-[1.55] text-[#0f172a] bg-white placeholder:text-[rgba(15,23,42,0.32)] focus:outline-none focus:border-[#ca5f15] focus:shadow-[0_0_0_4px_rgba(202,95,21,0.12)] transition-[border-color,box-shadow] duration-180";
+  const labelClass = "text-[0.6875rem] font-bold tracking-[0.18em] uppercase text-[rgba(15,23,42,0.45)] dark:text-slate-400";
+  const inputClass = "w-full bg-transparent border-0 border-b-[1.5px] border-[rgba(15,23,42,0.10)] dark:border-b-slate-600 py-2 px-0 text-lg leading-[1.3] -tracking-[0.01em] text-[#0f172a] dark:text-slate-100 placeholder:text-[rgba(15,23,42,0.30)] dark:placeholder:text-slate-500 placeholder:font-normal focus:outline-none focus:border-b-[#ca5f15] transition-[border-color] duration-180";
+  const textareaClass = "w-full resize-none border border-[rgba(15,23,42,0.10)] dark:border-slate-700 rounded-2xl p-4 text-[0.95rem] leading-[1.55] text-[#0f172a] dark:text-slate-100 bg-white dark:bg-slate-900 placeholder:text-[rgba(15,23,42,0.32)] dark:placeholder:text-slate-500 focus:outline-none focus:border-[#ca5f15] focus:shadow-[0_0_0_4px_rgba(202,95,21,0.12)] transition-[border-color,box-shadow] duration-180";
   const btnPrimaryClass = "inline-flex items-center gap-2 bg-[#ca5f15] text-white font-bold text-sm -tracking-[0.005em] py-3 px-5 rounded-xl shadow-[inset_0_1px_0_rgba(255,255,255,0.18),_0_1px_2px_rgba(202,95,21,0.30),_0_10px_24px_-10px_rgba(202,95,21,0.55)] hover:bg-[#b35211] hover:-translate-y-px active:translate-y-0 disabled:bg-[rgba(15,23,42,0.10)] disabled:text-[rgba(15,23,42,0.35)] disabled:shadow-none disabled:cursor-not-allowed disabled:transform-none transition-[transform,box-shadow,background-color] duration-180 cursor-pointer";
-  const btnGhostClass = "inline-flex items-center gap-1.5 bg-transparent text-[rgba(15,23,42,0.65)] font-semibold text-sm py-3 px-4 rounded-xl hover:bg-[rgba(15,23,42,0.05)] hover:text-[#0f172a] transition-[background-color,color] duration-180 cursor-pointer";
-  const closeBtnClass = "inline-flex items-center justify-center w-9 h-9 rounded-full text-[rgba(15,23,42,0.50)] hover:bg-[rgba(15,23,42,0.05)] hover:text-[#0f172a] hover:rotate-90 transition-[background-color,color,transform] duration-180 cursor-pointer";
+  const btnGhostClass = "inline-flex items-center gap-1.5 bg-transparent text-[rgba(15,23,42,0.65)] dark:text-slate-300 font-semibold text-sm py-3 px-4 rounded-xl hover:bg-[rgba(15,23,42,0.05)] dark:hover:bg-slate-700 hover:text-[#0f172a] dark:hover:text-slate-100 transition-[background-color,color] duration-180 cursor-pointer";
+  const closeBtnClass = "inline-flex items-center justify-center w-9 h-9 rounded-full text-[rgba(15,23,42,0.50)] dark:text-slate-400 hover:bg-[rgba(15,23,42,0.05)] dark:hover:bg-slate-700 hover:text-[#0f172a] dark:hover:text-slate-100 hover:rotate-90 transition-[background-color,color,transform] duration-180 cursor-pointer";
   const dotClass = "inline-block w-1.5 h-1.5 rounded-full bg-[#ca5f15] shadow-[0_0_0_3px_rgba(202,95,21,0.18)]";
-  const counterClass = "tabular-nums text-[0.6875rem] text-[rgba(15,23,42,0.40)] tracking-[0.04em]";
+  const counterClass = "tabular-nums text-[0.6875rem] text-[rgba(15,23,42,0.40)] dark:text-slate-500 tracking-[0.04em]";
   const staggerClass = "stagger-container";
 
   return (
@@ -89,11 +89,11 @@ export function ModalNovaDemanda({ open, onClose, usuario, onSubmit }: ModalNova
 
           <div className={cn("px-5 sm:px-7 pt-4 sm:pt-5 pb-2", staggerClass)}>
             <header>
-              <h2 className="text-xl sm:text-2xl font-bold text-gray-900 tracking-tighter-2 leading-tight">
+              <h2 className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-slate-100 tracking-tighter-2 leading-tight">
                 Conte para a coordenação<br/>
                 <span className="text-gradient-warm">o que precisa ser resolvido.</span>
               </h2>
-              <p className="text-sm text-gray-500 mt-2 max-w-md">
+              <p className="text-sm text-gray-500 dark:text-slate-400 mt-2 max-w-md">
                 Quanto mais claro o pedido, mais rápida a análise. Inclua disciplina, datas e qualquer contexto relevante.
               </p>
             </header>
@@ -112,7 +112,7 @@ export function ModalNovaDemanda({ open, onClose, usuario, onSubmit }: ModalNova
                 ))}
               </select>
               {errors.tipo && (
-                <p className="text-xs text-red-600 mt-1">{errors.tipo.message}</p>
+                <p className="text-xs text-red-600 dark:text-red-400 mt-1">{errors.tipo.message}</p>
               )}
             </section>
 
@@ -138,7 +138,7 @@ export function ModalNovaDemanda({ open, onClose, usuario, onSubmit }: ModalNova
                       className={cn(inputClass, 'mt-1')}
                     />
                   )}
-                  {erro && <p className="text-xs text-red-600 mt-1">{erro}</p>}
+                  {erro && <p className="text-xs text-red-600 dark:text-red-400 mt-1">{erro}</p>}
                 </section>
               );
             })}
@@ -159,23 +159,23 @@ export function ModalNovaDemanda({ open, onClose, usuario, onSubmit }: ModalNova
                 className={cn(textareaClass, "mt-2")}
               />
               {errors.descricao && (
-                <p className="text-xs text-red-600 mt-1">{errors.descricao.message}</p>
+                <p className="text-xs text-red-600 dark:text-red-400 mt-1">{errors.descricao.message}</p>
               )}
             </section>
 
             {erroSubmit && (
-              <section className="mt-5 rounded-2xl bg-red-50 border border-red-200 px-4 py-3">
-                <p className="text-sm text-red-700">{erroSubmit}</p>
+              <section className="mt-5 rounded-2xl bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 px-4 py-3">
+                <p className="text-sm text-red-700 dark:text-red-300">{erroSubmit}</p>
               </section>
             )}
 
-            <section className="mt-5 flex items-center gap-3 bg-brand-surface rounded-2xl px-3.5 py-2.5 border border-gray-100">
+            <section className="mt-5 flex items-center gap-3 bg-brand-surface dark:bg-slate-900 rounded-2xl px-3.5 py-2.5 border border-gray-100 dark:border-slate-700">
               <div className="w-8 h-8 rounded-full bg-brand-primary text-white text-xs font-bold flex items-center justify-center shrink-0">
                 {inicial}
               </div>
               <div className="min-w-0">
                 <p className={cn(labelClass, "leading-none")}>Enviando como</p>
-                <p className="text-sm font-semibold text-gray-900 mt-1 truncate">
+                <p className="text-sm font-semibold text-gray-900 dark:text-slate-100 mt-1 truncate">
                   {usuario?.nome || 'Aluno'} · Matrícula {usuario?.matricula || '—'}
                 </p>
               </div>

--- a/clarify-next/src/components/demandas/TimelineProgresso.tsx
+++ b/clarify-next/src/components/demandas/TimelineProgresso.tsx
@@ -37,23 +37,23 @@ export function TimelineProgresso({ status }: TimelineProgressoProps) {
             key={passo.chave}
             className={[
               "relative flex flex-col items-center flex-1 min-w-0",
-              "[&+&]:before:content-[''] [&+&]:before:absolute [&+&]:before:left-[calc(-50%+14px)] [&+&]:before:right-[calc(50%+14px)] [&+&]:before:top-[13px] [&+&]:before:h-0.5 [&+&]:before:rounded-full [&+&]:before:bg-[rgba(15,23,42,0.10)]",
+              "[&+&]:before:content-[''] [&+&]:before:absolute [&+&]:before:left-[calc(-50%+14px)] [&+&]:before:right-[calc(50%+14px)] [&+&]:before:top-[13px] [&+&]:before:h-0.5 [&+&]:before:rounded-full [&+&]:before:bg-[rgba(15,23,42,0.10)] dark:[&+&]:before:bg-slate-600",
               isDone && "[&+&]:before:!bg-[#ca5f15]",
               isCurrent && "[&+&]:before:!bg-[linear-gradient(to_right,#ca5f15_0%,#ca5f15_60%,rgba(202,95,21,0.25)_100%)]",
             ].join(" ")}
           >
             <div
               className={[
-                "w-7 h-7 rounded-full bg-white border-2 border-[rgba(15,23,42,0.15)] flex items-center justify-center transition-all duration-220 relative z-[1]",
+                "w-7 h-7 rounded-full bg-white dark:bg-slate-800 border-2 border-[rgba(15,23,42,0.15)] dark:border-slate-600 flex items-center justify-center transition-all duration-220 relative z-[1]",
                 isDone && "!bg-[#ca5f15] !border-[#ca5f15] shadow-[0_4px_12px_-2px_rgba(202,95,21,0.35)]",
-                isCurrent && "!border-[#ca5f15] bg-white shadow-[0_0_0_5px_rgba(202,95,21,0.14),_0_4px_12px_-2px_rgba(202,95,21,0.25)] animate-pulse-glow after:content-[''] after:w-2.5 after:h-2.5 after:rounded-full after:bg-[#ca5f15]",
+                isCurrent && "!border-[#ca5f15] bg-white dark:bg-slate-800 shadow-[0_0_0_5px_rgba(202,95,21,0.14),_0_4px_12px_-2px_rgba(202,95,21,0.25)] animate-pulse-glow after:content-[''] after:w-2.5 after:h-2.5 after:rounded-full after:bg-[#ca5f15]",
               ].join(" ")}
             >
               {isDone && <Check className="w-3.5 h-3.5 text-white" />}
             </div>
             <p
               className={[
-                "text-[0.6875rem] font-bold tracking-[0.14em] uppercase text-[rgba(15,23,42,0.35)] mt-3 text-center leading-[1.2] transition-colors duration-220",
+                "text-[0.6875rem] font-bold tracking-[0.14em] uppercase text-[rgba(15,23,42,0.35)] dark:text-slate-500 mt-3 text-center leading-[1.2] transition-colors duration-220",
                 isDone && "!text-[rgba(202,95,21,0.85)]",
                 isCurrent && "!text-[#ca5f15]",
               ].join(" ")}

--- a/clarify-next/src/components/layout/DrawerMobile.tsx
+++ b/clarify-next/src/components/layout/DrawerMobile.tsx
@@ -46,20 +46,20 @@ export function DrawerMobile({
 
       {/* Drawer com slide lateral */}
       <div
-        className={`fixed inset-y-0 left-0 z-50 w-64 bg-white shadow-lg md:hidden overflow-y-auto transition-transform duration-300 ease-out ${
+        className={`fixed inset-y-0 left-0 z-50 w-64 bg-white dark:bg-slate-800 shadow-lg md:hidden overflow-y-auto transition-transform duration-300 ease-out ${
           open ? 'translate-x-0' : '-translate-x-full'
         }`}
       >
         {/* Header com botão fechar */}
-        <div className="flex items-center justify-between p-4 border-b border-gray-200">
+        <div className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-slate-700">
           <span className="font-bold text-orange-600 text-lg">Clarify</span>
           <button
             type="button"
             onClick={onClose}
-            className="p-2 hover:bg-gray-100 rounded-lg transition-colors"
+            className="p-2 hover:bg-gray-100 dark:hover:bg-slate-700 rounded-lg transition-colors"
             aria-label="Fechar menu"
           >
-            <X className="w-5 h-5 text-gray-600" />
+            <X className="w-5 h-5 text-gray-600 dark:text-slate-400" />
           </button>
         </div>
 

--- a/clarify-next/src/components/layout/Sidebar.tsx
+++ b/clarify-next/src/components/layout/Sidebar.tsx
@@ -47,7 +47,7 @@ export function Sidebar({
         ];
 
   return (
-    <aside className="flex flex-col w-64 bg-gray-50 shadow border-r border-gray-200 p-5 shrink-0 h-screen overflow-y-auto">
+    <aside className="flex flex-col w-64 bg-gray-50 dark:bg-slate-900 shadow border-r border-gray-200 dark:border-slate-700 p-5 shrink-0 h-screen overflow-y-auto">
       {/* Logo */}
       <div className="mb-6 flex items-center gap-3 px-2">
         <Image
@@ -70,7 +70,7 @@ export function Sidebar({
             className={`flex items-center gap-3 rounded-xl px-4 py-3 text-left font-medium transition-colors ${
               currentView === id
                 ? 'bg-orange-50 text-orange-600'
-                : 'text-gray-700 hover:bg-orange-50 hover:text-orange-600'
+                : 'text-gray-700 dark:text-slate-300 hover:bg-orange-50 hover:text-orange-600'
             }`}
             aria-current={currentView === id ? 'page' : undefined}
           >

--- a/clarify-next/src/components/layout/ThemeToggle.tsx
+++ b/clarify-next/src/components/layout/ThemeToggle.tsx
@@ -12,7 +12,7 @@ export function ThemeToggle() {
       type="button"
       onClick={alternarTema}
       aria-label={escuro ? 'Ativar tema claro' : 'Ativar tema escuro'}
-      className="flex items-center justify-center w-10 h-10 rounded-xl text-gray-600 hover:bg-gray-100 hover:text-gray-900 transition-colors cursor-pointer"
+      className="flex items-center justify-center w-10 h-10 rounded-xl text-gray-600 dark:text-slate-400 hover:bg-gray-100 dark:hover:bg-slate-700 hover:text-gray-900 dark:hover:text-slate-100 transition-colors cursor-pointer"
     >
       {escuro ? <Sun className="w-5 h-5" /> : <Moon className="w-5 h-5" />}
     </button>

--- a/clarify-next/src/components/layout/ThemeToggle.tsx
+++ b/clarify-next/src/components/layout/ThemeToggle.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { Moon, Sun } from 'lucide-react';
+import { useTheme } from '@/context/ThemeContext';
+
+export function ThemeToggle() {
+  const { tema, alternarTema } = useTheme();
+  const escuro = tema === 'dark';
+
+  return (
+    <button
+      type="button"
+      onClick={alternarTema}
+      aria-label={escuro ? 'Ativar tema claro' : 'Ativar tema escuro'}
+      className="flex items-center justify-center w-10 h-10 rounded-xl text-gray-600 hover:bg-gray-100 hover:text-gray-900 transition-colors cursor-pointer"
+    >
+      {escuro ? <Sun className="w-5 h-5" /> : <Moon className="w-5 h-5" />}
+    </button>
+  );
+}

--- a/clarify-next/src/components/layout/TopbarDesktop.tsx
+++ b/clarify-next/src/components/layout/TopbarDesktop.tsx
@@ -15,7 +15,7 @@ interface TopbarDesktopProps {
  */
 export function TopbarDesktop({ usuario, onLogout }: TopbarDesktopProps) {
   return (
-    <header className="hidden md:flex items-center justify-between h-16 px-6 bg-white border-b border-gray-200 shadow-sm">
+    <header className="hidden md:flex items-center justify-between h-16 px-6 bg-white dark:bg-slate-800 border-b border-gray-200 dark:border-slate-700 shadow-sm">
       <div className="flex-1" />
       <div className="flex items-center gap-3">
         <ThemeToggle />

--- a/clarify-next/src/components/layout/TopbarDesktop.tsx
+++ b/clarify-next/src/components/layout/TopbarDesktop.tsx
@@ -2,6 +2,7 @@
 
 import type { UsuarioLogado } from '@/types';
 import { UserChip } from './UserChip';
+import { ThemeToggle } from './ThemeToggle';
 
 interface TopbarDesktopProps {
   usuario: UsuarioLogado | null;
@@ -16,7 +17,10 @@ export function TopbarDesktop({ usuario, onLogout }: TopbarDesktopProps) {
   return (
     <header className="hidden md:flex items-center justify-between h-16 px-6 bg-white border-b border-gray-200 shadow-sm">
       <div className="flex-1" />
-      <UserChip usuario={usuario} onLogout={onLogout} showName={true} />
+      <div className="flex items-center gap-3">
+        <ThemeToggle />
+        <UserChip usuario={usuario} onLogout={onLogout} showName={true} />
+      </div>
     </header>
   );
 }

--- a/clarify-next/src/components/layout/TopbarMobile.tsx
+++ b/clarify-next/src/components/layout/TopbarMobile.tsx
@@ -21,7 +21,7 @@ export function TopbarMobile({
   onMenuClick,
 }: TopbarMobileProps) {
   return (
-    <header className="md:hidden flex items-center justify-between h-14 px-4 bg-white border-b border-gray-200 shadow-sm gap-3">
+    <header className="md:hidden flex items-center justify-between h-14 px-4 bg-white dark:bg-slate-800 border-b border-gray-200 dark:border-slate-700 shadow-sm gap-3">
       {/* Logo + Título */}
       <div className="flex items-center gap-2">
         <Image
@@ -41,10 +41,10 @@ export function TopbarMobile({
           <button
             type="button"
             onClick={onMenuClick}
-            className="p-2 hover:bg-gray-100 rounded-lg transition-colors"
+            className="p-2 hover:bg-gray-100 dark:hover:bg-slate-700 rounded-lg transition-colors"
             aria-label="Abrir menu"
           >
-            <Menu className="w-5 h-5 text-gray-600" />
+            <Menu className="w-5 h-5 text-gray-600 dark:text-slate-400" />
           </button>
         )}
 

--- a/clarify-next/src/components/layout/UserChip.tsx
+++ b/clarify-next/src/components/layout/UserChip.tsx
@@ -21,7 +21,7 @@ export function UserChip({ usuario, onLogout, showName = true }: UserChipProps) 
   const inicial = primeiroNome.charAt(0).toUpperCase();
 
   return (
-    <div className="flex items-center gap-2 bg-white border border-gray-200 rounded-full pl-2 pr-1 py-1 shadow-sm">
+    <div className="flex items-center gap-2 bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 rounded-full pl-2 pr-1 py-1 shadow-sm">
       {/* Avatar */}
       <div className="w-8 h-8 rounded-full bg-orange-100 text-orange-600 text-sm font-bold flex items-center justify-center">
         {inicial}
@@ -29,7 +29,7 @@ export function UserChip({ usuario, onLogout, showName = true }: UserChipProps) 
 
       {/* Nome (hidden em LG) */}
       {showName && (
-        <span className="text-sm font-medium text-gray-700 hidden lg:inline">
+        <span className="text-sm font-medium text-gray-700 dark:text-slate-300 hidden lg:inline">
           {nome}
         </span>
       )}

--- a/clarify-next/src/components/ui/Badge.tsx
+++ b/clarify-next/src/components/ui/Badge.tsx
@@ -8,13 +8,13 @@ interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
 }
 
 const variantClasses: Record<Variant, string> = {
-  pendente: 'bg-yellow-100 text-yellow-800',
-  em_analise: 'bg-blue-100 text-blue-800',
-  requer_ajuste: 'bg-orange-100 text-orange-800',
-  concluido: 'bg-green-100 text-green-800',
+  pendente: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/40 dark:text-yellow-200',
+  em_analise: 'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-200',
+  requer_ajuste: 'bg-orange-100 text-orange-800 dark:bg-orange-900/40 dark:text-orange-200',
+  concluido: 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200',
   default: 'bg-gray-100 dark:bg-slate-700 text-gray-800 dark:text-slate-100',
-  orange: 'bg-orange-100 text-orange-700',
-  blue: 'bg-blue-100 text-blue-700',
+  orange: 'bg-orange-100 text-orange-700 dark:bg-orange-900/40 dark:text-orange-200',
+  blue: 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-200',
 }
 
 export function Badge({ className, variant = 'default', ...props }: BadgeProps) {

--- a/clarify-next/src/components/ui/Badge.tsx
+++ b/clarify-next/src/components/ui/Badge.tsx
@@ -12,7 +12,7 @@ const variantClasses: Record<Variant, string> = {
   em_analise: 'bg-blue-100 text-blue-800',
   requer_ajuste: 'bg-orange-100 text-orange-800',
   concluido: 'bg-green-100 text-green-800',
-  default: 'bg-gray-100 text-gray-800',
+  default: 'bg-gray-100 dark:bg-slate-700 text-gray-800 dark:text-slate-100',
   orange: 'bg-orange-100 text-orange-700',
   blue: 'bg-blue-100 text-blue-700',
 }

--- a/clarify-next/src/components/ui/Card.tsx
+++ b/clarify-next/src/components/ui/Card.tsx
@@ -7,7 +7,7 @@ export function Card({ className, ...props }: CardProps) {
   return (
     <div
       className={cn(
-        'bg-white rounded-xl border border-gray-200 shadow-lg',
+        'bg-white dark:bg-slate-800 rounded-xl border border-gray-200 dark:border-slate-700 shadow-lg',
         className
       )}
       {...props}

--- a/clarify-next/src/components/ui/Dialog.tsx
+++ b/clarify-next/src/components/ui/Dialog.tsx
@@ -46,7 +46,7 @@ function DialogContent({
       >
         <div
           className={cn(
-            "w-full sm:max-w-lg bg-white rounded-t-3xl sm:rounded-3xl overflow-hidden",
+            "w-full sm:max-w-lg bg-white dark:bg-slate-800 dark:text-slate-100 rounded-t-3xl sm:rounded-3xl overflow-hidden",
             "max-h-[calc(100vh-2rem)] sm:max-h-[calc(100vh-4rem)]",
             "shadow-[inset_0_1px_0_rgba(255,255,255,0.6),_0_1px_2px_rgba(15,23,42,0.04),_0_12px_32px_-12px_rgba(15,23,42,0.18),_0_40px_80px_-28px_rgba(202,95,21,0.22)]"
           )}
@@ -74,7 +74,7 @@ function DialogFooter({ className, ...props }: React.HTMLAttributes<HTMLDivEleme
   return (
     <div
       className={cn(
-        "flex items-center justify-between gap-3 px-5 sm:px-7 py-4 mt-3 border-t border-gray-100 bg-gradient-to-b from-white to-brand-surface/40",
+        "flex items-center justify-between gap-3 px-5 sm:px-7 py-4 mt-3 border-t border-gray-100 dark:border-slate-700 bg-gradient-to-b from-white dark:from-slate-800 to-brand-surface/40",
         className
       )}
       {...props}
@@ -103,7 +103,7 @@ function DialogDescription({
 }: React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>) {
   return (
     <DialogPrimitive.Description
-      className={cn("text-sm text-gray-500", className)}
+      className={cn("text-sm text-gray-500 dark:text-slate-400", className)}
       {...props}
     />
   )

--- a/clarify-next/src/context/ThemeContext.tsx
+++ b/clarify-next/src/context/ThemeContext.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import { createContext, use, useEffect, useState, ReactNode } from 'react'
+
+type Tema = 'light' | 'dark'
+
+interface ThemeContextValue {
+  tema: Tema
+  alternarTema: () => void
+}
+
+const CHAVE_TEMA = 'clarify_tema'
+
+const ThemeContext = createContext<ThemeContextValue | null>(null)
+
+// No servidor não há localStorage: assume 'light'. O cliente lê a preferência
+// salva já na inicialização do estado, sem efeito extra de sincronização.
+function temaInicial(): Tema {
+  if (typeof window === 'undefined') return 'light'
+  return localStorage.getItem(CHAVE_TEMA) === 'dark' ? 'dark' : 'light'
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [tema, setTema] = useState<Tema>(temaInicial)
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', tema === 'dark')
+    localStorage.setItem(CHAVE_TEMA, tema)
+  }, [tema])
+
+  const alternarTema = () => setTema((t) => (t === 'dark' ? 'light' : 'dark'))
+
+  return (
+    <ThemeContext.Provider value={{ tema, alternarTema }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}
+
+export function useTheme(): ThemeContextValue {
+  const ctx = use(ThemeContext)
+  if (!ctx) {
+    throw new Error('useTheme deve ser usado dentro de um ThemeProvider')
+  }
+  return ctx
+}

--- a/clarify-next/src/lib/utils.ts
+++ b/clarify-next/src/lib/utils.ts
@@ -53,10 +53,10 @@ export function obterLabelStatus(status: StatusDemanda): string {
 // Obtém a cor (Tailwind) de um status
 export function obterCorStatus(status: StatusDemanda): string {
   const cores: Record<StatusDemanda, string> = {
-    pendente: 'bg-yellow-100 text-yellow-800',
-    em_analise: 'bg-blue-100 text-blue-800',
-    requer_ajuste: 'bg-orange-100 text-orange-800',
-    concluido: 'bg-green-100 text-green-800',
+    pendente: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/40 dark:text-yellow-200',
+    em_analise: 'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-200',
+    requer_ajuste: 'bg-orange-100 text-orange-800 dark:bg-orange-900/40 dark:text-orange-200',
+    concluido: 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200',
   };
   return cores[status];
 }

--- a/clarify-next/tailwind.config.ts
+++ b/clarify-next/tailwind.config.ts
@@ -1,6 +1,7 @@
 import type { Config } from 'tailwindcss'
 
 export default {
+  darkMode: 'class',
   content: ['./src/**/*.{ts,tsx}'],
   theme: {
     extend: {


### PR DESCRIPTION
Dark mode **completo** (não é mais só fundação). Toggle sol/lua no topbar do dashboard, preferência persistida em `localStorage`.

## Cobertura
Migração por superfície, toda via **adição de variantes `dark:`** (nunca altera classe light → light mode fica byte-idêntico):
- **Componentes compartilhados** (`ui/Card`, `ui/Dialog`, `ui/Badge`) → conserta **todos os modais e cards** de uma vez.
- **Chrome** do dashboard: Sidebar, TopbarDesktop/Mobile, DrawerMobile, UserChip.
- **Demandas (aluno):** centraldemandas + `components/demandas/*` (cards, modais, filtros, timeline).
- **Coordenador:** dashboardcoord + `_components/*` e `components/coordenador/*` (modais, listas, métricas).
- **Auth/público:** login, registro, landing, not-found.
- **Perfil:** painel + formulários + troca de senha.
- **Cores de status** centralizadas (`obterCorStatus` + variantes do `Badge`) com tints escuros legíveis.

## Mecânica (Tailwind v4)
`@custom-variant dark (&:where(.dark, .dark *))` no `globals.css` (o `darkMode:'class'` do config é no-op no v4). Provider aplica `.dark` no `<html>`.

## Verificação (build real)
Com deps instaladas: `npm ci` limpo, `tsc --noEmit` **0 erros**, `next build` **passa** (todas as rotas prerenderizam). A branch já foi reconciliada com a `develop` atual (merge resolvido em `UserChip` e `ListaAlunos`).

## Gaps conhecidos (fora desta branch)
- Páginas de **reset de senha** (`/recuperar-senha`, `/redefinir-senha`) estão no **#138** (ainda aberto) — recebem o mesmo passo `dark:` quando aquele PR entrar.
- Utilitários `brand-*`/`font-sans` mortos no v4 (config não carregado) → rastreado em **ENZ-205** (afeta light e dark, não é regressão deste PR).

## Como testar
1. App rodando, entrar no dashboard, clicar no **toggle sol/lua** no topo.
2. Percorrer: central de demandas, abrir uma demanda (modal), dashboard do coordenador, /perfil, e deslogar → login/landing.
3. Recarregar → preferência **persiste** (`localStorage clarify_tema`).
4. Voltar pro light → **idêntico** ao de antes.

## O que testar
- [ ] Todas as superfícies coerentes em dark (cards/modais/sidebar/topbar/inputs/badges).
- [x] Light mode sem nenhuma regressão.
- [ ] Sem erro de hidratação no console (possível 1 frame de FOUC pra quem usa dark — conhecido, fix anti-FOUC em ENZ-205).
- [ ] Contraste legível (texto claro sobre slate, badges de status legíveis).

Fecha ENZ-54 (fundação + migração das superfícies presentes nesta branch).
