### PR TITLE
fix(dark-mode): corrige contraste de texto e dropdown no dark mode

### DIFF
--- a/clarify-next/src/app/(dashboard)/dashboardcoord/_components/DemandaCard.tsx
+++ b/clarify-next/src/app/(dashboard)/dashboardcoord/_components/DemandaCard.tsx
@@ -19,11 +19,11 @@ export function DemandaCard({ demanda: d, onVerDetalhes, onAprovar, onReprovar }
       >
         <div className="flex items-start justify-between gap-4 mb-4">
           <div className="min-w-0 space-y-2">
-            <h3 className="text-lg font-semibold text-gray-900 truncate">{d.tipo}</h3>
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-slate-100 truncate">{d.tipo}</h3>
             {d.aluno?.nome && (
-              <p className="text-sm text-gray-600 font-medium">{d.aluno.nome}</p>
+              <p className="text-sm text-gray-600 dark:text-slate-300 font-medium">{d.aluno.nome}</p>
             )}
-            <p className="text-sm text-gray-500 line-clamp-2">{d.descricao}</p>
+            <p className="text-sm text-gray-500 dark:text-slate-300 line-clamp-2">{d.descricao}</p>
           </div>
           <span className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold shrink-0 ${
             d.status === 'pendente' ? 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/40 dark:text-yellow-200' :

--- a/clarify-next/src/components/demandas/BarraFiltros.tsx
+++ b/clarify-next/src/components/demandas/BarraFiltros.tsx
@@ -48,7 +48,7 @@ export function BarraFiltros({
           className="pl-8 pr-7 py-2 border border-gray-200 dark:border-slate-700 rounded-lg bg-gray-50 dark:bg-slate-900 text-sm dark:text-slate-100 appearance-none cursor-pointer outline-none focus:border-brand-primary focus:bg-white dark:focus:bg-slate-800 transition-colors"
         >
           {OPCOES_STATUS.map((op) => (
-            <option key={op.valor} value={op.valor}>
+            <option key={op.valor} value={op.valor} className="dark:bg-slate-800 dark:text-slate-100">
               {op.label}
             </option>
           ))}

--- a/clarify-next/src/components/demandas/CardDemanda.tsx
+++ b/clarify-next/src/components/demandas/CardDemanda.tsx
@@ -45,9 +45,9 @@ export function CardDemanda({ demanda, onVerDetalhes }: CardDemandaProps) {
           {demanda.tipo}
         </h3>
         {demanda.aluno?.nome && (
-          <p className="text-sm text-gray-600 font-medium mt-1">{demanda.aluno.nome}</p>
+          <p className="text-sm text-gray-600 dark:text-slate-300 font-medium mt-1">{demanda.aluno.nome}</p>
         )}
-        <p className="text-sm text-gray-600 mt-1 line-clamp-2 break-words [overflow-wrap:anywhere]">
+        <p className="text-sm text-gray-600 dark:text-slate-300 mt-1 line-clamp-2 break-words [overflow-wrap:anywhere]">
           {demanda.descricao}
         </p>
       </div>

--- a/clarify-next/src/components/demandas/ModalNovaDemanda.tsx
+++ b/clarify-next/src/components/demandas/ModalNovaDemanda.tsx
@@ -106,9 +106,9 @@ export function ModalNovaDemanda({ open, onClose, usuario, onSubmit }: ModalNova
                 className={cn(inputClass, "font-semibold mt-1")}
                 defaultValue=""
               >
-                <option value="" disabled>Selecione o tipo de solicitação</option>
+                <option value="" disabled className="dark:bg-slate-800 dark:text-slate-100">Selecione o tipo de solicitação</option>
                 {TIPOS_DEMANDA.map((tipo) => (
-                  <option key={tipo} value={tipo}>{tipo}</option>
+                  <option key={tipo} value={tipo} className="dark:bg-slate-800 dark:text-slate-100">{tipo}</option>
                 ))}
               </select>
               {errors.tipo && (


### PR DESCRIPTION
## 📝 Resumo

Corrige contraste de texto no dark mode em cards de demanda e dropdown de selecao.

## 💡 Por que

No dark mode, textos do nome da demanda, aluno e descricao estavam escuros (sem classe `dark:`) e o dropdown de tipos de demanda tinha fundo branco com texto claro, impossibilitando a leitura.

## 🛠️ O que mudou

- `CardDemanda.tsx` — Adiciona `dark:text-slate-300` ao nome do aluno e descricao
- `DemandaCard.tsx` — Adiciona `dark:text-slate-100` ao nome da demanda e `dark:text-slate-300` ao aluno e descricao
- `ModalNovaDemanda.tsx` — Adiciona `dark:bg-slate-800 dark:text-slate-100` nas opcoes do select
- `BarraFiltros.tsx` — Adiciona `dark:bg-slate-800 dark:text-slate-100` nas opcoes do select

## 🧪 Como testar

1. `npm run dev`
2. Ativar dark mode
3. Abrir o modal de nova demanda e clicar no dropdown "Tipo de Solicitacao" — opcoes devem ter fundo escuro e texto legivel
4. Na central de demandas (aluno) e dashboard (coordenador), conferir se nome da demanda, aluno e descricao estao claros

## ✅ Checklist

- [ ] Rodei `npm run dev` e testei no navegador
- [ ] Rodei `npm run build` e nao deu erro
- [ ] Nao tem `console.log` ou comentario `[OBS:]` esquecido
- [ ] Os imports que nao estao sendo usados foram removidos
- [ ] Se mexi em algo do design system (style.css, tailwind.config.js), conferi se outras telas continuam funcionando
